### PR TITLE
Feature/campaign template (#2) : 캠페인 템플릿 등록 코드 추가 및 Admin 관련 메소드 추가 + swagger 적용

### DIFF
--- a/LearnsMate/build.gradle
+++ b/LearnsMate/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
 //    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/dto/AdminDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/dto/AdminDTO.java
@@ -1,6 +1,6 @@
 package intbyte4.learnsmate.admin.domain.dto;
 
-
+import intbyte4.learnsmate.admin.domain.entity.Admin;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class AdminDTO {
     private Long adminCode;
     private String adminEmail;
@@ -26,4 +27,24 @@ public class AdminDTO {
     private LocalDateTime adminLastLoginDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public Admin convertToEntity() {
+        return Admin.builder()
+                .adminCode(this.adminCode)
+                .adminEmail(this.adminEmail)
+                .adminPassword(this.adminPassword)
+                .adminDepartment(this.adminDepartment)
+                .adminPosition(this.adminPosition)
+                .adminName(this.adminName)
+                .adminPhone(this.adminPhone)
+                .adminAddress(this.adminAddress)
+                .adminBirthday(this.adminBirthday)
+                .adminJobType(this.adminJobType)
+                .adminLevel(this.adminLevel)
+                .adminStatus(this.adminStatus)
+                .adminLastLoginDate(this.adminLastLoginDate)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .build();
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/entity/Admin.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/entity/Admin.java
@@ -1,6 +1,6 @@
 package intbyte4.learnsmate.admin.domain.entity;
 
-
+import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -61,4 +61,23 @@ public class Admin {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    public AdminDTO convertToDTO() {
+        return AdminDTO.builder()
+                .adminCode(this.adminCode)
+                .adminEmail(this.adminEmail)
+                .adminPassword(this.adminPassword)
+                .adminDepartment(this.adminDepartment)
+                .adminPosition(this.adminPosition)
+                .adminName(this.adminName)
+                .adminPhone(this.adminPhone)
+                .adminAddress(this.adminAddress)
+                .adminBirthday(this.adminBirthday)
+                .adminJobType(this.adminJobType)
+                .adminLevel(this.adminLevel)
+                .adminStatus(this.adminStatus)
+                .adminLastLoginDate(this.adminLastLoginDate)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .build();
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
@@ -1,4 +1,7 @@
 package intbyte4.learnsmate.admin.service;
 
+import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+
 public interface AdminService {
+    AdminDTO findByAdminCode(Long adminCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
@@ -1,10 +1,24 @@
 package intbyte4.learnsmate.admin.service;
 
 
+import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.admin.repository.AdminRepository;
+import intbyte4.learnsmate.common.exception.CommonException;
+import intbyte4.learnsmate.common.exception.StatusEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public AdminDTO findByAdminCode(Long adminCode) {
+        Admin admin = adminRepository.findById(adminCode).orElseThrow(()-> new CommonException(StatusEnum.ADMIN_NOT_FOUND));
+
+        return admin.convertToDTO();
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/controller/CampaignTemplateController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/controller/CampaignTemplateController.java
@@ -1,6 +1,17 @@
 package intbyte4.learnsmate.campaigntemplate.controller;
 
+import intbyte4.learnsmate.campaigntemplate.domain.dto.CampaignTemplateDTO;
+import intbyte4.learnsmate.campaigntemplate.domain.vo.request.RequestRegisterTemplateVO;
+import intbyte4.learnsmate.campaigntemplate.domain.vo.response.ResponseRegisterTemplateVO;
+import intbyte4.learnsmate.campaigntemplate.service.CampaignTemplateService;
+import intbyte4.learnsmate.common.exception.CommonException;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +20,38 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class CampaignTemplateController {
 
+    private final CampaignTemplateService campaignTemplateService;
+
+    @Autowired
+    public CampaignTemplateController(final CampaignTemplateService campaignTemplateService) {
+        this.campaignTemplateService = campaignTemplateService;
+    }
+
+    @Operation(summary = "직원 - 캠페인 템플릿 등록")
+    @PostMapping("/register")
+    public ResponseEntity<?> registerTemplate(@RequestBody final RequestRegisterTemplateVO request) {
+        log.info("템플릿 등록 요청 : {}", request);
+        try {
+            CampaignTemplateDTO campaignTemplateDTO = new CampaignTemplateDTO();
+
+            CampaignTemplateDTO registerCampaignTemplate = campaignTemplateService.registerTemplate(campaignTemplateDTO);
+
+            ResponseRegisterTemplateVO response = new ResponseRegisterTemplateVO(
+                    registerCampaignTemplate.getCampaignTemplateCode(),
+                    registerCampaignTemplate.getCampaignTemplateTitle(),
+                    registerCampaignTemplate.getCampaignTemplateContents(),
+                    registerCampaignTemplate.getCampaignTemplateFlag(),
+                    registerCampaignTemplate.getAdminCode()
+            );
+
+            log.info("캠페인 템플릿 등록 성공: {}", response);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (CommonException e) {
+            log.error("캠페인 템플릿 등록 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/CampaignTemplate.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/CampaignTemplate.java
@@ -1,8 +1,12 @@
 package intbyte4.learnsmate.campaigntemplate.domain;
 
+import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.campaigntemplate.domain.dto.CampaignTemplateDTO;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
 
 @Entity(name = "CampaignTemplate")
 @Table(name = "campaign_template")
@@ -19,20 +23,35 @@ public class CampaignTemplate {
     @Column(name = "campaign_template_code", nullable = false, unique = true)
     private Long campaignTemplateCode;
 
-    @Column(name = "campaign_template_title", nullable = false, unique = true)
+    @Column(name = "campaign_template_title", nullable = false)
     private String campaignTemplateTitle;
 
-    @Column(name = "campaign_template_contents", nullable = false, unique = true)
+    @Column(name = "campaign_template_contents", nullable = false)
     private String campaignTemplateContents;
 
-    @Column(name = "campaign_template_flag", nullable = false, unique = true)
+    @Column(name = "campaign_template_flag", nullable = false)
     @ColumnDefault("true")
     private Boolean campaignTemplateFlag;
 
-//    @ManyToOne
-//    @JoinColumn(name = "admin_code", nullable = false)
-//    private Admin admin;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
-    @Column(name = "admin_code", nullable = false)
-    private Long adminCode;
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "admin_code", nullable = false)
+    private Admin admin;
+
+    public CampaignTemplateDTO convertToCampaignDTO() {
+        return CampaignTemplateDTO.builder()
+                .campaignTemplateCode(this.campaignTemplateCode)
+                .campaignTemplateTitle(this.campaignTemplateTitle)
+                .campaignTemplateContents(this.campaignTemplateContents)
+                .campaignTemplateFlag(this.campaignTemplateFlag)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .adminCode(this.admin.getAdminCode())
+                .build();
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/dto/CampaignTemplateDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/dto/CampaignTemplateDTO.java
@@ -1,0 +1,36 @@
+package intbyte4.learnsmate.campaigntemplate.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class CampaignTemplateDTO {
+
+    @JsonProperty("campaign_template_code")
+    private Long campaignTemplateCode;
+
+    @JsonProperty("campaign_template_title")
+    private String campaignTemplateTitle;
+
+    @JsonProperty("campaign_template_contents")
+    private String campaignTemplateContents;
+
+    @JsonProperty("campaign_template_flag")
+    private Boolean campaignTemplateFlag;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
+    private Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/vo/request/RequestRegisterTemplateVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/vo/request/RequestRegisterTemplateVO.java
@@ -1,0 +1,19 @@
+package intbyte4.learnsmate.campaigntemplate.domain.vo.request;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class RequestRegisterTemplateVO {
+
+    private final Long campaignTemplateCode;
+    private final String campaignTemplateTitle;
+    private final String campaignTemplateContents;
+    private final Boolean campaignTemplateFlag;
+    private final Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/vo/response/ResponseRegisterTemplateVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/domain/vo/response/ResponseRegisterTemplateVO.java
@@ -1,0 +1,19 @@
+package intbyte4.learnsmate.campaigntemplate.domain.vo.response;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ResponseRegisterTemplateVO {
+
+    private final Long campaignTemplateCode;
+    private final String campaignTemplateTitle;
+    private final String campaignTemplateContents;
+    private final Boolean campaignTemplateFlag;
+    private final Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/repository/CampaignTemplateRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/repository/CampaignTemplateRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CampaignTemplateRepository extends JpaRepository<CampaignTemplate, Integer> {
+public interface CampaignTemplateRepository extends JpaRepository<CampaignTemplate, Long> {
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateService.java
@@ -1,7 +1,8 @@
 package intbyte4.learnsmate.campaigntemplate.service;
 
+import intbyte4.learnsmate.campaigntemplate.domain.dto.CampaignTemplateDTO;
 import org.springframework.stereotype.Service;
 
-@Service
 public interface CampaignTemplateService {
+    CampaignTemplateDTO registerTemplate(CampaignTemplateDTO campaignTemplateDTO);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateServiceImpl.java
@@ -1,12 +1,56 @@
 package intbyte4.learnsmate.campaigntemplate.service;
 
+import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.admin.service.AdminService;
+import intbyte4.learnsmate.campaigntemplate.domain.CampaignTemplate;
+import intbyte4.learnsmate.campaigntemplate.domain.dto.CampaignTemplateDTO;
 import intbyte4.learnsmate.campaigntemplate.repository.CampaignTemplateRepository;
+import intbyte4.learnsmate.common.exception.CommonException;
+import intbyte4.learnsmate.common.exception.StatusEnum;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Slf4j
+@Service("campaignTemplateService")
 public class CampaignTemplateServiceImpl implements CampaignTemplateService {
 
     private final CampaignTemplateRepository campaignTemplateRepository;
+    private final AdminService adminService;
+
+    @Override
+    @Transactional
+    public CampaignTemplateDTO registerTemplate(CampaignTemplateDTO campaignTemplateDTO) {
+        log.info("템플릿 등록 중: {}", campaignTemplateDTO);
+        campaignTemplateDTO.setAdminCode(campaignTemplateDTO.getAdminCode());
+
+        AdminDTO adminDTO = adminService.findByAdminCode(campaignTemplateDTO.getAdminCode());
+        if (adminDTO == null) {
+            log.warn("존재하지 않는 사용자 : {}", campaignTemplateDTO.getAdminCode());
+            throw new CommonException(StatusEnum.USER_NOT_FOUND);
+        }
+        log.info(adminDTO.toString());
+
+        Admin user = adminDTO.convertToEntity();
+
+        CampaignTemplate campaignTemplate = new CampaignTemplate();
+        campaignTemplate.setCampaignTemplateCode(campaignTemplateDTO.getCampaignTemplateCode());
+        campaignTemplate.setCampaignTemplateTitle(campaignTemplateDTO.getCampaignTemplateTitle());
+        campaignTemplate.setCampaignTemplateContents(campaignTemplateDTO.getCampaignTemplateContents());
+        campaignTemplate.setCampaignTemplateFlag(campaignTemplateDTO.getCampaignTemplateFlag());
+        campaignTemplate.setCreatedAt(LocalDateTime.now());
+        campaignTemplate.setUpdatedAt(LocalDateTime.now());
+        campaignTemplate.setAdmin(user);
+
+        log.info("데이터베이스에 템플릿 저장 중: {}", campaignTemplate);
+        CampaignTemplate saveCampaignTemplate = campaignTemplateRepository.save(campaignTemplate);
+        log.info("저장된 템플릿 객체: {}", saveCampaignTemplate);
+
+        return saveCampaignTemplate.convertToCampaignDTO();
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/SwaggerConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/SwaggerConfig.java
@@ -1,0 +1,14 @@
+package intbyte4.learnsmate.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/* http://localhost:8080/swagger-ui/index.html */
+@OpenAPIDefinition(
+        info = @Info(title = "LearnsMate API 명세서",
+                description = "LearnsMate 기능별 API 명세서"))
+@Configuration
+public class SwaggerConfig {
+
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
@@ -17,6 +17,7 @@ public enum StatusEnum {
     RESTRICTED(403, HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
 
     USER_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    ADMIN_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 직원입니다."),
     EMAIL_NOT_FOUND(404, HttpStatus.NOT_FOUND, "회원가입 되지않은 아이디 입니다."),
 
     INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- Admin 예외처리를 위해 추가
- Admin <-> AdminDTO 간 convert 메소드 추가
- swagger 추가
- 캠페인 템플릿 등록 코드 추가 (컨트롤러, 서비스)

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/438113a9-944d-430c-a35f-afefaf36ad2e)

코드 작성 + 잘 실행되는지도 확인했습니다.
<br/>

## 🔧 앞으로의 과제

- 캠페인 템플릿 수정, 삭제, 조회 관련 기능 추가

  <br/>

close #2 