### PR TITLE
✨ 기능 추가: 캠페인 등록 기능을 위한 registCampaign 메서드 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/dto/CampaignDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/dto/CampaignDTO.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @ToString
 @Getter
 @Setter
+@Builder
 public class CampaignDTO {
     @JsonProperty("campaign_code")
     private Long campaignCode;
@@ -26,9 +27,13 @@ public class CampaignDTO {
     @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
 
-    @JsonProperty("campaign_template_code")
-    private Long campaignTemplateCode;
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
 
     @JsonProperty("admin_code")
     private Long adminCode;
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/Campaign.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/Campaign.java
@@ -1,6 +1,7 @@
 package intbyte4.learnsmate.campaign.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -26,15 +27,31 @@ public class Campaign {
     private String campaignContents;
 
     @Column(name = "campaign_type")
-    private String campaignType;
+    private CampaignTypeEnum campaignType;
 
     @Column(name = "campaign_send_date")
     private LocalDateTime campaignSendDate;
 
-    @Column(name = "campaign_template_code")
-    private Long campaignTemplateCode;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
-    @Column(name = "admin_code")
-    private Long adminCode;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
+    @ManyToOne
+    @JoinColumn(name = "admin_code", nullable = false)
+    private Admin admin;
+
+    public CampaignDTO toDTO() {
+        CampaignDTO campaignDTO = new CampaignDTO();
+        campaignDTO.setCampaignCode(this.getCampaignCode());
+        campaignDTO.setCampaignTitle(this.getCampaignTitle());
+        campaignDTO.setCampaignContents(this.getCampaignContents());
+        campaignDTO.setCampaignType(String.valueOf(this.campaignType));
+        campaignDTO.setCampaignSendDate(this.getCampaignSendDate());
+        campaignDTO.setCreatedAt(this.getCreatedAt());
+        campaignDTO.setUpdatedAt(this.getUpdatedAt());
+        campaignDTO.setAdminCode(this.admin.getAdminCode());
+        return campaignDTO;
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/CampaignTypeEnum.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/CampaignTypeEnum.java
@@ -1,0 +1,19 @@
+package intbyte4.learnsmate.campaign.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum CampaignTypeEnum {
+    INSTANT("INSTANT"),
+    RESERVATION("RESERVATION");
+
+    private final String campaignType;
+
+    CampaignTypeEnum(String campaignType) {
+        this.campaignType = campaignType;
+    }
+
+    @JsonValue
+    public String getType() {
+        return campaignType;
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -1,5 +1,8 @@
 package intbyte4.learnsmate.campaign.service;
 
+import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
+
 public interface CampaignService {
+    CampaignDTO registCampaign(CampaignDTO request);
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -1,10 +1,53 @@
 package intbyte4.learnsmate.campaign.service;
 
+import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.admin.service.AdminService;
+import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
+import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
+import intbyte4.learnsmate.campaign.repository.CampaignRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
-public class CampaignServiceImpl implements CampaignService{
+public class CampaignServiceImpl implements CampaignService {
+    private final CampaignRepository campaignRepository;
+    private final AdminService adminService;
+
+    @Override
+    public CampaignDTO registCampaign(CampaignDTO request) {
+
+        LocalDateTime sendTime;
+
+        AdminDTO adminDTO = adminService.findByAdminCode(request.getAdminCode());
+        Admin admin = adminDTO.convertToEntity();
+
+        if (Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+            sendTime = LocalDateTime.now();
+        } else {
+            sendTime = request.getCampaignSendDate();
+        };
+
+        Campaign campaign = Campaign.builder()
+                .campaignCode(null)
+                .campaignTitle(request.getCampaignTitle())
+                .campaignContents(request.getCampaignContents())
+                .campaignType(CampaignTypeEnum.valueOf(request.getCampaignType()))
+                .campaignSendDate(sendTime)
+                .createdAt(request.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .admin(admin)
+                .build();
+
+        campaignRepository.save(campaign);
+
+        return campaign.toDTO();
+    }
 
 }


### PR DESCRIPTION
- 제목 : feat(#3 ): 캠페인 등록 기능을 위한 registCampaign 메서드 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 즉시발송/예약발송에 따라 sendDate가 바뀌도록 캠페인 등록 기능을 만들었습니다.

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/faa8f4f8-317c-40e8-9c30-5447d464e0c1)


<br/>

## 🔧 앞으로의 과제

- 캠페인 수정 기능

  <br/>

close #3 
