### PR TITLE
feat(#36 ): 캠페인 삭제 API 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/controller/CampaignTemplateController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/controller/CampaignTemplateController.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController("campaignTemplateController")
-@RequestMapping("campaigntemplate")
+@RequestMapping("campaign-template")
 @Slf4j
 @RequiredArgsConstructor
 public class CampaignTemplateController {
@@ -46,7 +46,7 @@ public class CampaignTemplateController {
         }
     }
 
-    @PatchMapping("/{campaignTemplateCode}")
+    @PatchMapping("/edit/{campaignTemplateCode}")
     public ResponseEntity<?> editTemplate(@PathVariable("campaignTemplateCode") Long campaignTemplateCode, @RequestBody RequestEditTemplateVO request) {
         log.info("템플릿 수정 요청 : {}", request);
         try {
@@ -61,6 +61,25 @@ public class CampaignTemplateController {
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         } catch (CommonException e) {
             log.error("캠페인 템플릿 수정 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
+    }
+
+    @PatchMapping("/delete/{campaignTemplateCode}")
+    public ResponseEntity<?> deleteTemplate(@PathVariable("campaignTemplateCode") Long campaignTemplateCode) {
+        log.info("템플릿 삭제 요청된 템플릿 코드 : {}", campaignTemplateCode);
+        try {
+            CampaignTemplateDTO campaignTemplateDTO = new CampaignTemplateDTO();
+            campaignTemplateDTO.setCampaignTemplateCode(campaignTemplateCode);
+
+            campaignTemplateService.deleteTemplate(campaignTemplateDTO);
+
+            return ResponseEntity.status(HttpStatus.OK).body("성공적으로 삭제되었습니다.");
+        } catch (CommonException e) {
+            log.error("캠페인 템플릿 삭제 오류: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (Exception e) {
             log.error("예상치 못한 오류", e);

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateService.java
@@ -6,4 +6,6 @@ public interface CampaignTemplateService {
     CampaignTemplateDTO registerTemplate(CampaignTemplateDTO campaignTemplateDTO);
 
     CampaignTemplateDTO editTemplate(CampaignTemplateDTO campaignTemplateDTO);
+
+    CampaignTemplateDTO deleteTemplate(CampaignTemplateDTO campaignTemplateDTO);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaigntemplate/service/CampaignTemplateServiceImpl.java
@@ -52,23 +52,31 @@ public class CampaignTemplateServiceImpl implements CampaignTemplateService {
     @Transactional
     public CampaignTemplateDTO editTemplate(CampaignTemplateDTO campaignTemplateDTO) {
         log.info("템플릿 수정 중: {}", campaignTemplateDTO);
-        campaignTemplateDTO.setAdminCode(campaignTemplateDTO.getAdminCode());
-
-        AdminDTO adminDTO = adminService.findByAdminCode(campaignTemplateDTO.getAdminCode());
-        if (adminDTO == null) {
-            log.warn("존재하지 않는 직원 : {}", campaignTemplateDTO.getAdminCode());
-            throw new CommonException(StatusEnum.ADMIN_NOT_FOUND);
-        }
 
         CampaignTemplate campaignTemplate = campaignTemplateRepository.findById(campaignTemplateDTO.getCampaignTemplateCode()).orElseThrow(() -> new CommonException(StatusEnum.TEMPLATE_NOT_FOUND));
         campaignTemplate.setCampaignTemplateTitle(campaignTemplateDTO.getCampaignTemplateTitle());
         campaignTemplate.setCampaignTemplateContents(campaignTemplateDTO.getCampaignTemplateContents());
         campaignTemplate.setUpdatedAt(LocalDateTime.now());
 
-        log.info("데이터베이스에 템플릿 저장 중: {}", campaignTemplate);
+        log.info("데이터베이스에 수정된 템플릿 저장 중: {}", campaignTemplate);
         CampaignTemplate updatedCampaignTemplate = campaignTemplateRepository.save(campaignTemplate);
         log.info("수정된 템플릿 객체: {}", updatedCampaignTemplate);
 
         return campaignTemplateMapper.fromEntityToDto(updatedCampaignTemplate);
+    }
+
+    @Override
+    @Transactional
+    public CampaignTemplateDTO deleteTemplate(CampaignTemplateDTO campaignTemplateDTO) {
+        log.info("템플릿 삭제 중: {}", campaignTemplateDTO);
+
+        CampaignTemplate campaignTemplate = campaignTemplateRepository.findById(campaignTemplateDTO.getCampaignTemplateCode()).orElseThrow(() -> new CommonException(StatusEnum.TEMPLATE_NOT_FOUND));
+        campaignTemplate.setCampaignTemplateFlag(false);
+
+        log.info("데이터베이스에 해당 템플릿 삭제 처리 중: {}", campaignTemplate);
+        CampaignTemplate deletedCampaignTemplate = campaignTemplateRepository.save(campaignTemplate);
+        log.info("삭제 처리된 템플릿 객체: {}", deletedCampaignTemplate);
+
+        return campaignTemplateMapper.fromEntityToDto(deletedCampaignTemplate);
     }
 }


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
우선 DTO에 삭제 원하는 템플릿 코드를 넣고 나머지는 NULL인 상태로 서비스 코드에서 넣어줬던 템플릿 코드로 찾아온 뒤, Flag 를 False로 나타내 삭제 처리를 해주었습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/88d65af3-e022-49b9-b8ad-2b719a493582)

<br/>

## 🔧 앞으로의 과제

- 조회 API 추가

  <br/>

close #36 