### PR TITLE
✨ 기능 추가: CampaignService -> 캠페인 취소 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -31,11 +31,21 @@ public class CampaignController {
     }
 
     @Operation(summary = "직원 - 예약된 캠페인 수정")
-    @PutMapping("/{campaignCode}")
+    @PutMapping("/edit/{campaignCode}")
     public ResponseEntity<ResponseEditCampaignVO> updateCampaign(@RequestBody RequestEditCampaignVO request
             , @PathVariable("campaignCode") Long campaignCode) {
         CampaignDTO campaignDTO = campaignService.editCampaign(campaignMapper.fromEditRequestVOtoDTO(request)
                 , campaignCode);
         return ResponseEntity.status(HttpStatus.CREATED).body(campaignMapper.fromDtoToEditResponseVO(campaignDTO));
+    }
+
+    @Operation(summary = "직원 - 예약된 캠페인 취소")
+    @DeleteMapping("/delete/{campaignCode}")
+    public ResponseEntity<Void> deleteCampaign(@PathVariable("campaignCode") Long campaignCode) {
+        CampaignDTO getCampaignCode = new CampaignDTO();
+        getCampaignCode.setCampaignCode(campaignCode);
+        campaignService.removeCampaign(getCampaignCode);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/dto/CampaignDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/dto/CampaignDTO.java
@@ -1,6 +1,5 @@
 package intbyte4.learnsmate.campaign.domain.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -12,28 +11,13 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 public class CampaignDTO {
-    @JsonProperty("campaign_code")
     private Long campaignCode;
-
-    @JsonProperty("campaign_title")
     private String campaignTitle;
-
-    @JsonProperty("campaign_contents")
     private String campaignContents;
-
-    @JsonProperty("campaign_type")
     private String campaignType;
-
-    @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
-
-    @JsonProperty("created_at")
     private LocalDateTime createdAt;
-
-    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
-
-    @JsonProperty("admin_code")
     private Long adminCode;
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignVO.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.campaign.domain.vo.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,9 +13,16 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class RequestEditCampaignVO {
+    @JsonProperty("campaign_title")
     private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
     private String campaignContents;
+
+    @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestRegisterCampaignVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestRegisterCampaignVO.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.campaign.domain.vo.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,13 +13,28 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class RequestRegisterCampaignVO {
+    @JsonProperty("campaign_code")
     private Long campaignCode;
+
+    @JsonProperty("campaign_title")
     private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
     private String campaignContents;
+
+    @JsonProperty("campaign_type")
     private String campaignType;
+
+    @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
+
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
     private Long adminCode;
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseEditCampaignVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseEditCampaignVO.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.campaign.domain.vo.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -10,13 +11,28 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 public class ResponseEditCampaignVO {
+    @JsonProperty("campaign_code")
     private Long campaignCode;
+
+    @JsonProperty("campaign_title")
     private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
     private String campaignContents;
+
+    @JsonProperty("campaign_type")
     private String campaignType;
+
+    @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
+
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
     private Long adminCode;
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseRegisterCampaignVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseRegisterCampaignVO.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.campaign.domain.vo.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -10,13 +11,28 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 public class ResponseRegisterCampaignVO {
+    @JsonProperty("campaign_code")
     private Long campaignCode;
+
+    @JsonProperty("campaign_title")
     private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
     private String campaignContents;
+
+    @JsonProperty("campaign_type")
     private String campaignType;
+
+    @JsonProperty("campaign_send_date")
     private LocalDateTime campaignSendDate;
+
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
     private Long adminCode;
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -5,4 +5,5 @@ import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 public interface CampaignService {
     CampaignDTO registerCampaign(CampaignDTO request);
     CampaignDTO editCampaign(CampaignDTO request, Long campaignCode);
+    void removeCampaign(CampaignDTO request);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -72,4 +72,15 @@ public class CampaignServiceImpl implements CampaignService {
 
         return campaignMapper.toDTO(updatedCampaign);
     }
+
+    @Override
+    public void removeCampaign(CampaignDTO request){
+        Campaign campaign = campaignRepository.findById(request.getCampaignCode())
+                .orElseThrow(() -> new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND));
+        if(Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+            throw new CommonException(StatusEnum.DELETE_NOT_ALLOWED);
+        }
+
+        campaignRepository.delete(campaign);
+    }
 }


### PR DESCRIPTION
- 제목 : feat(#45 ): 캠페인 취소 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 예약된 캠페인은 취소 될 수 있습니다.

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/444cc7e3-1a9e-43d6-94ff-cfeb9dded146)


<br/>

## 🔧 앞으로의 과제

- 캠페인 전체 조회

  <br/>

close(#45 )
