### PR TITLE
✨ 기능 추가: CampaignService -> 캠페인 전체 조회 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -4,15 +4,18 @@ import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseRegisterCampaignVO;
+import intbyte4.learnsmate.campaign.mapper.CampaignMapper;
 import intbyte4.learnsmate.campaign.service.CampaignService;
-import intbyte4.learnsmate.common.mapper.CampaignMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController("campaignController")
 @RequestMapping("campaign")
@@ -47,5 +50,15 @@ public class CampaignController {
         campaignService.removeCampaign(getCampaignCode);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(summary = "직원 - 캠페인 전체 조회")
+    @GetMapping("/campaigns")
+    public ResponseEntity<List<ResponseFindCampaignVO>> getAllCampaigns() {
+        List<CampaignDTO> campaignDTOList = campaignService.findAllCampaigns();
+        List<ResponseFindCampaignVO> responseFindCampaignVOList = campaignMapper
+                .fromDtoListToFindCampaignVO(campaignDTOList);
+
+        return new ResponseEntity<>(responseFindCampaignVOList, HttpStatus.OK);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/Campaign.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/entity/Campaign.java
@@ -1,7 +1,6 @@
 package intbyte4.learnsmate.campaign.domain.entity;
 
 import intbyte4.learnsmate.admin.domain.entity.Admin;
-import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseFindCampaignVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseFindCampaignVO.java
@@ -1,0 +1,37 @@
+package intbyte4.learnsmate.campaign.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ResponseFindCampaignVO {
+    @JsonProperty("campaign_code")
+    private Long campaignCode;
+
+    @JsonProperty("campaign_title")
+    private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
+    private String campaignContents;
+
+    @JsonProperty("campaign_type")
+    private String campaignType;
+
+    @JsonProperty("campaign_send_date")
+    private LocalDateTime campaignSendDate;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
+    private Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
@@ -1,4 +1,4 @@
-package intbyte4.learnsmate.common.mapper;
+package intbyte4.learnsmate.campaign.mapper;
 
 
 import intbyte4.learnsmate.admin.domain.entity.Admin;
@@ -8,15 +8,18 @@ import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseRegisterCampaignVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
-public class CampaignMapper{
+public class CampaignMapper {
 
     public CampaignDTO toDTO(Campaign entity) {
         return CampaignDTO.builder()
@@ -92,4 +95,16 @@ public class CampaignMapper{
                 .build();
     }
 
+    public List<ResponseFindCampaignVO> fromDtoListToFindCampaignVO(List<CampaignDTO> dtoList) {
+        return dtoList.stream().map(dto -> ResponseFindCampaignVO.builder()
+                .campaignCode(dto.getCampaignCode())
+                .campaignTitle(dto.getCampaignTitle())
+                .campaignContents(dto.getCampaignContents())
+                .campaignType(dto.getCampaignType())
+                .campaignSendDate(dto.getCampaignSendDate())
+                .createdAt(dto.getCreatedAt())
+                .updatedAt(dto.getUpdatedAt())
+                .adminCode(dto.getAdminCode())
+                .build()).collect(Collectors.toList());
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -2,8 +2,11 @@ package intbyte4.learnsmate.campaign.service;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 
+import java.util.List;
+
 public interface CampaignService {
     CampaignDTO registerCampaign(CampaignDTO request);
     CampaignDTO editCampaign(CampaignDTO request, Long campaignCode);
     void removeCampaign(CampaignDTO request);
+    List<CampaignDTO> findAllCampaigns();
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -6,15 +6,17 @@ import intbyte4.learnsmate.admin.service.AdminService;
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
+import intbyte4.learnsmate.campaign.mapper.CampaignMapper;
 import intbyte4.learnsmate.campaign.repository.CampaignRepository;
 
 import intbyte4.learnsmate.common.exception.CommonException;
 import intbyte4.learnsmate.common.exception.StatusEnum;
-import intbyte4.learnsmate.common.mapper.CampaignMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -82,5 +84,14 @@ public class CampaignServiceImpl implements CampaignService {
         }
 
         campaignRepository.delete(campaign);
+    }
+
+    @Override
+    public List<CampaignDTO> findAllCampaigns(){
+        List<Campaign> campaign = campaignRepository.findAll();
+        List<CampaignDTO> campaignDTOList = new ArrayList<>();
+        campaign.forEach(dto -> campaignDTOList.add(campaignMapper.toDTO(dto)));
+
+        return campaignDTOList;
     }
 }


### PR DESCRIPTION
- 제목 : feat(#50 ): 캠페인 전체 조회 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 보내진/보내질 전체 캠페인을 조회할 수 있습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/41840e2f-cb24-43e7-a9fe-8830a77bd1f9)


<br/>

## 🔧 앞으로의 과제

- 캠페인 코드로 캠페인 단건 조회 기능

  <br/>
