### PR TITLE
✨ 기능 추가: CampaignService -> 캠페인 단건 조회 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -2,6 +2,7 @@ package intbyte4.learnsmate.campaign.controller;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignByCampaignCodeVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
@@ -60,5 +61,15 @@ public class CampaignController {
                 .fromDtoListToFindCampaignVO(campaignDTOList);
 
         return new ResponseEntity<>(responseFindCampaignVOList, HttpStatus.OK);
+    }
+
+    @Operation(summary = "직원 - 캠페인 단건 조회")
+    @GetMapping("/campaign")
+    public ResponseEntity<ResponseFindCampaignVO> getCampaign
+            (@RequestBody RequestFindCampaignByCampaignCodeVO requestFindCampaignByCampaignCodeVO) {
+        CampaignDTO getCampaignCode = campaignMapper.fromFindRequestVOtoDTO(requestFindCampaignByCampaignCodeVO);
+        CampaignDTO campaignDTO = campaignService.findCampaign(getCampaignCode);
+
+        return ResponseEntity.status(HttpStatus.OK).body(campaignMapper.fromDtoToFindResponseVO(campaignDTO));
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestFindCampaignByCampaignCodeVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestFindCampaignByCampaignCodeVO.java
@@ -1,0 +1,17 @@
+package intbyte4.learnsmate.campaign.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class RequestFindCampaignByCampaignCodeVO {
+    @JsonProperty("campaign_code")
+    private Long campaignCode;
+}
+

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
@@ -6,6 +6,7 @@ import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignByCampaignCodeVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
@@ -107,4 +108,20 @@ public class CampaignMapper {
                 .adminCode(dto.getAdminCode())
                 .build()).collect(Collectors.toList());
     }
+
+    public CampaignDTO fromFindRequestVOtoDTO(RequestFindCampaignByCampaignCodeVO vo) {
+        return CampaignDTO.builder()
+                .campaignCode(vo.getCampaignCode())
+                .build();
+    }
+
+    public ResponseFindCampaignVO fromDtoToFindResponseVO(CampaignDTO dto) {
+        return ResponseFindCampaignVO.builder()
+                .campaignCode(dto.getCampaignCode())
+                .campaignTitle(dto.getCampaignTitle())
+                .campaignType(dto.getCampaignType())
+                .campaignSendDate(dto.getCampaignSendDate())
+                .build();
+    }
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -9,4 +9,6 @@ public interface CampaignService {
     CampaignDTO editCampaign(CampaignDTO request, Long campaignCode);
     void removeCampaign(CampaignDTO request);
     List<CampaignDTO> findAllCampaigns();
+
+    CampaignDTO findCampaign(CampaignDTO request);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -94,4 +94,11 @@ public class CampaignServiceImpl implements CampaignService {
 
         return campaignDTOList;
     }
+
+    @Override
+    public CampaignDTO findCampaign(CampaignDTO request){
+        Campaign campaign = campaignRepository.findById(request.getCampaignCode())
+                .orElseThrow(() -> new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND));
+        return campaignMapper.toDTO(campaign);
+    }
 }


### PR DESCRIPTION
- 제목 : feat(#53  ): 캠페인 단건 조회 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 캠페인 코드로 캠페인 단건 조회가 가능합니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/7a842395-0765-479a-8e9f-b88c3964e096)

<br/>

## 🔧 앞으로의 과제

- 제목으로 조회, 기간별 조회, 발송타입별 조회, 발송된 캠페인 조회, 발송될 캠페인 조회

  <br/>
