### PR TITLE
feat(#56, #57 ): VOC 전체 조회, 단 건 조회 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
@@ -25,6 +25,7 @@ public enum StatusEnum {
     EMAIL_NOT_FOUND(404, HttpStatus.NOT_FOUND, "회원가입 되지 않은 아이디입니다."),
     TEMPLATE_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 템플릿입니다."),
     CAMPAIGN_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 캠페인입니다."),
+    VOC_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 VOC 입니다."),
 
     INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VocController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VocController.java
@@ -1,0 +1,41 @@
+package intbyte4.learnsmate.voc.controller;
+
+import intbyte4.learnsmate.voc.domain.dto.VocDTO;
+import intbyte4.learnsmate.voc.domain.vo.response.ResponseFindVocVO;
+import intbyte4.learnsmate.voc.mapper.VocMapper;
+import intbyte4.learnsmate.voc.service.VocService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController("vocController")
+@RequestMapping("voc")
+@Slf4j
+@RequiredArgsConstructor
+public class VocController {
+
+    private final VocService vocService;
+    private final VocMapper vocMapper;
+
+    @Operation(summary = "직원 - VOC 전체 조회")
+    @GetMapping("/list")
+    public ResponseEntity<List<ResponseFindVocVO>> listTemplates() {
+        List<VocDTO> vocDTOList = vocService.findAllByVoc();
+        List<ResponseFindVocVO> responseList = new ArrayList<>();
+
+        for (VocDTO vocDTO : vocDTOList) {
+            ResponseFindVocVO responseFindTemplateVO = vocMapper.fromDtoToFindResponseVO(vocDTO);
+            responseList.add(responseFindTemplateVO);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VocController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VocController.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.voc.controller;
 
+import intbyte4.learnsmate.common.exception.CommonException;
 import intbyte4.learnsmate.voc.domain.dto.VocDTO;
 import intbyte4.learnsmate.voc.domain.vo.response.ResponseFindVocVO;
 import intbyte4.learnsmate.voc.mapper.VocMapper;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,5 +39,27 @@ public class VocController {
         }
 
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Operation(summary = "직원 - VOC 단 건 조회")
+    @GetMapping("/{vocCode}")
+    public ResponseEntity<?> getTemplate(@PathVariable("vocCode") Long vocCode) {
+        log.info("조회 요청된 VOC 코드 : {}", vocCode);
+        try {
+            VocDTO vocDTO = new VocDTO();
+            vocDTO.setVocCode(vocCode);
+
+            VocDTO findVocDTO = vocService.findByVocCode(vocDTO);
+            ResponseFindVocVO response = vocMapper.fromDtoToFindResponseVO(findVocDTO);
+
+            log.info("캠페인 템플릿 조회 성공: {}", response);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (CommonException e) {
+            log.error("캠페인 템플릿 조회 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("예상치 못한 오류가 발생했습니다");
+        }
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/Voc.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/Voc.java
@@ -1,0 +1,47 @@
+package intbyte4.learnsmate.voc.domain;
+
+import intbyte4.learnsmate.member.domain.entity.Member;
+import intbyte4.learnsmate.voc_category.domain.VocCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "Voc")
+@Table(name = "voc")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class Voc {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "voc_code", nullable = false, unique = true)
+    private Long vocCode;
+
+    @Column(name = "voc_content", nullable = false)
+    private String vocContent;
+
+    @Column(name = "voc_answer_status", nullable = false)
+    private int vocAnswerStatus;
+
+    @Column(name = "voc_answer_satisfaction")
+    private String vocAnswerSatisfaction;
+
+    @Column(name = "voc_analysis", nullable = false)
+    private String vocAnalysis;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "voc_category_code", nullable = false)
+    private VocCategory vocCategory;
+
+    @ManyToOne
+    @JoinColumn(name = "member_code", nullable = false)
+    private Member member;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/dto/VocDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/dto/VocDTO.java
@@ -1,0 +1,27 @@
+package intbyte4.learnsmate.voc.domain.dto;
+
+import intbyte4.learnsmate.member.domain.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class VocDTO {
+
+    private Long vocCode;
+    private String vocContent;
+    private int vocAnswerStatus;
+    private String vocAnswerSatisfaction;
+    private String vocAnalysis;
+    private LocalDateTime createdAt;
+    private int vocCategoryCode;
+    private Long memberCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/vo/response/ResponseFindVocVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/vo/response/ResponseFindVocVO.java
@@ -1,0 +1,30 @@
+package intbyte4.learnsmate.voc.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@RequiredArgsConstructor
+@Builder
+public class ResponseFindVocVO {
+    @JsonProperty("voc_code")
+    private Long vocCode;
+    @JsonProperty("voc_content")
+    private String vocContent;
+    @JsonProperty("voc_answer_status")
+    private int vocAnswerStatus;
+    @JsonProperty("voc_answer_satisfaction")
+    private String vocAnswerSatisfaction;
+    @JsonProperty("voc_analysis")
+    private String vocAnalysis;
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+    @JsonProperty("voc_category_code")
+    private int vocCategoryCode;
+    @JsonProperty("member_code")
+    private Long memberCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/mapper/VocMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/mapper/VocMapper.java
@@ -1,0 +1,33 @@
+package intbyte4.learnsmate.voc.mapper;
+
+import intbyte4.learnsmate.voc.domain.Voc;
+import intbyte4.learnsmate.voc.domain.dto.VocDTO;
+import intbyte4.learnsmate.voc.domain.vo.response.ResponseFindVocVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VocMapper {
+    public VocDTO fromEntityToDto(Voc voc) {
+        return VocDTO.builder()
+                .vocCode(voc.getVocCode())
+                .vocContent(voc.getVocContent())
+                .vocAnswerStatus(voc.getVocAnswerStatus())
+                .vocAnswerSatisfaction(voc.getVocAnswerSatisfaction())
+                .vocAnalysis(voc.getVocAnalysis())
+                .vocCategoryCode(voc.getVocCategory().getVocCategoryCode())
+                .memberCode(voc.getMember().getMemberCode())
+                .build();
+    }
+
+    public ResponseFindVocVO fromDtoToFindResponseVO(VocDTO vocDTO) {
+        return ResponseFindVocVO.builder()
+                .vocCode(vocDTO.getVocCode())
+                .vocContent(vocDTO.getVocContent())
+                .vocAnswerStatus(vocDTO.getVocAnswerStatus())
+                .vocAnswerSatisfaction(vocDTO.getVocAnswerSatisfaction())
+                .vocAnalysis(vocDTO.getVocAnalysis())
+                .vocCategoryCode(vocDTO.getVocCategoryCode())
+                .memberCode(vocDTO.getMemberCode())
+                .build();
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VocRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VocRepository.java
@@ -1,0 +1,9 @@
+package intbyte4.learnsmate.voc.repository;
+
+import intbyte4.learnsmate.voc.domain.Voc;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VocRepository extends JpaRepository<Voc, Long> {
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface VocService {
     List<VocDTO> findAllByVoc();
+
+    VocDTO findByVocCode(VocDTO vocDTO);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocService.java
@@ -1,0 +1,9 @@
+package intbyte4.learnsmate.voc.service;
+
+import intbyte4.learnsmate.voc.domain.dto.VocDTO;
+
+import java.util.List;
+
+public interface VocService {
+    List<VocDTO> findAllByVoc();
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocServiceImpl.java
@@ -1,5 +1,7 @@
 package intbyte4.learnsmate.voc.service;
 
+import intbyte4.learnsmate.common.exception.CommonException;
+import intbyte4.learnsmate.common.exception.StatusEnum;
 import intbyte4.learnsmate.voc.domain.Voc;
 import intbyte4.learnsmate.voc.domain.dto.VocDTO;
 import intbyte4.learnsmate.voc.mapper.VocMapper;
@@ -30,5 +32,14 @@ public class VocServiceImpl implements VocService {
         }
 
         return vocDTOList;
+    }
+
+    @Override
+    public VocDTO findByVocCode(VocDTO vocDTO) {
+        log.info("템플릿 단 건 조회 중: {}", vocDTO);
+        Voc voc = vocRepository.findById(vocDTO.getVocCode())
+                .orElseThrow(() -> new CommonException(StatusEnum.VOC_NOT_FOUND));
+
+        return vocMapper.fromEntityToDto(voc);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VocServiceImpl.java
@@ -1,0 +1,34 @@
+package intbyte4.learnsmate.voc.service;
+
+import intbyte4.learnsmate.voc.domain.Voc;
+import intbyte4.learnsmate.voc.domain.dto.VocDTO;
+import intbyte4.learnsmate.voc.mapper.VocMapper;
+import intbyte4.learnsmate.voc.repository.VocRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service("vocService")
+@RequiredArgsConstructor
+public class VocServiceImpl implements VocService {
+
+    private final VocRepository vocRepository;
+    private final VocMapper vocMapper;
+
+    @Override
+    public List<VocDTO> findAllByVoc() {
+        log.info("템플릿 전체 조회 중");
+        List<Voc> vocList = vocRepository.findAll();
+        List<VocDTO> vocDTOList = new ArrayList<>();
+
+        for (Voc voc : vocList) {
+            vocDTOList.add(vocMapper.fromEntityToDto(voc));
+        }
+
+        return vocDTOList;
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc_category/domain/VocCategory.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc_category/domain/VocCategory.java
@@ -1,0 +1,23 @@
+package intbyte4.learnsmate.voc_category.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity(name = "VocCategory")
+@Table(name = "voc_category")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class VocCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "voc_category_code", nullable = false, unique = true)
+    private Integer vocCategoryCode;
+
+    @Column(name = "voc_category_name", nullable = false)
+    private String vocCategoryName;
+}


### PR DESCRIPTION
- 제목 : feat(#56, #57 ): VOC 전체 조회, 단 건 조회 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
VOC 컨트롤러, 서비스, 리포지토리, Mapper, DTO, VO로 전체 조회, 단 건 조회 로직을 구현했습니다.

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- VOC 답변의 CRUD를 담당해서 만들 예정입니다.

  <br/>

close #56, #57