### PR TITLE
feat(#86 ): 발급 쿠폰 등록 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/controller/IssueCouponController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/controller/IssueCouponController.java
@@ -1,0 +1,40 @@
+package intbyte4.learnsmate.issue_coupon.controller;
+
+import intbyte4.learnsmate.issue_coupon.domain.dto.IssueCouponDTO;
+import intbyte4.learnsmate.issue_coupon.domain.vo.request.IssueCouponRegisterRequestVO;
+import intbyte4.learnsmate.issue_coupon.domain.vo.response.IssueCouponRegisterResponseVO;
+import intbyte4.learnsmate.issue_coupon.mapper.IssueCouponMapper;
+import intbyte4.learnsmate.issue_coupon.service.IssueCouponService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController("issueCouponController")
+@RequestMapping("issue-coupon")
+@Slf4j
+@RequiredArgsConstructor
+public class IssueCouponController {
+
+    private final IssueCouponService issueCouponService;
+    private final IssueCouponMapper issueCouponMapper;
+
+    @Operation(summary = "학생에게 쿠폰 발급")
+    @PostMapping("/register")
+    public ResponseEntity<List<IssueCouponRegisterResponseVO>> registerIssuedCoupons(@RequestBody IssueCouponRegisterRequestVO request) {
+        List<IssueCouponDTO> issuedCoupons = issueCouponService.issueCouponsToStudents(request);
+        List<IssueCouponRegisterResponseVO> responseList = issuedCoupons.stream()
+                .map(issueCouponMapper::fromDtoToResponseVO)
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(responseList, HttpStatus.CREATED);
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/IssueCoupon.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/IssueCoupon.java
@@ -1,0 +1,42 @@
+package intbyte4.learnsmate.issue_coupon.domain;
+
+import intbyte4.learnsmate.coupon.domain.entity.CouponEntity;
+import intbyte4.learnsmate.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "IssueCoupon")
+@Table(name = "issue_coupon")
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Getter
+@Builder
+@Where(clause = "member_type = 'STUDENT'")
+public class IssueCoupon {
+
+    @Id
+    @Column(name = "coupon_issuance_code", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int couponIssuanceCode;
+
+    @Column(name = "coupon_issue_date", nullable = false)
+    private LocalDateTime couponIssueDate;
+
+    @Column(name = "coupon_use_status", nullable = false)
+    private Boolean couponUseStatus;
+
+    @Column(name = "coupon_use_date")
+    private LocalDateTime couponUseDate;
+
+    @ManyToOne
+    @JoinColumn (name = "student_code")
+    private Member student;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_code")
+    private CouponEntity coupon;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/dto/IssueCouponDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/dto/IssueCouponDTO.java
@@ -1,0 +1,20 @@
+package intbyte4.learnsmate.issue_coupon.domain.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class IssueCouponDTO {
+    private int couponIssuanceCode;
+    private LocalDateTime couponIssueDate;
+    private Boolean couponUseStatus;
+    private LocalDateTime couponUseDate;
+    private Long studentCode;
+    private Long couponCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/vo/request/IssueCouponRegisterRequestVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/vo/request/IssueCouponRegisterRequestVO.java
@@ -1,0 +1,22 @@
+package intbyte4.learnsmate.issue_coupon.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class IssueCouponRegisterRequestVO {
+
+    @JsonProperty("student_codes")
+    private List<Long> studentCodes;
+
+    @JsonProperty("coupon_codes")
+    private List<Long> couponCodes;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/vo/response/IssueCouponRegisterResponseVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/domain/vo/response/IssueCouponRegisterResponseVO.java
@@ -1,0 +1,33 @@
+package intbyte4.learnsmate.issue_coupon.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IssueCouponRegisterResponseVO {
+
+    @JsonProperty("coupon_issuance_code")
+    private int couponIssuanceCode;
+
+    @JsonProperty("coupon_issue_date")
+    private LocalDateTime couponIssueDate;
+
+    @JsonProperty("coupon_use_status")
+    private Boolean couponUseStatus;
+
+    @JsonProperty("coupon_use_date")
+    private LocalDateTime couponUseDate;
+
+    @JsonProperty("student_code")
+    private Long studentCode;
+
+    @JsonProperty("coupon_code")
+    private Long couponCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/mapper/IssueCouponMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/mapper/IssueCouponMapper.java
@@ -1,0 +1,31 @@
+package intbyte4.learnsmate.issue_coupon.mapper;
+
+import intbyte4.learnsmate.issue_coupon.domain.IssueCoupon;
+import intbyte4.learnsmate.issue_coupon.domain.dto.IssueCouponDTO;
+import intbyte4.learnsmate.issue_coupon.domain.vo.response.IssueCouponRegisterResponseVO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IssueCouponMapper {
+    public IssueCouponDTO toDTO(IssueCoupon issueCoupon) {
+        return IssueCouponDTO.builder()
+                .couponIssuanceCode(issueCoupon.getCouponIssuanceCode())
+                .couponIssueDate(issueCoupon.getCouponIssueDate())
+                .couponUseStatus(issueCoupon.getCouponUseStatus())
+                .couponUseDate(issueCoupon.getCouponUseDate())
+                .studentCode(issueCoupon.getStudent().getMemberCode())
+                .couponCode(issueCoupon.getCoupon().getCouponCode())
+                .build();
+    }
+
+    public IssueCouponRegisterResponseVO fromDtoToResponseVO(IssueCouponDTO issueCoupon) {
+        return IssueCouponRegisterResponseVO.builder()
+                .couponIssuanceCode(issueCoupon.getCouponIssuanceCode())
+                .couponIssueDate(issueCoupon.getCouponIssueDate())
+                .couponUseStatus(issueCoupon.getCouponUseStatus())
+                .couponUseDate(issueCoupon.getCouponUseDate())
+                .studentCode(issueCoupon.getStudentCode())
+                .couponCode(issueCoupon.getCouponCode())
+                .build();
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/repository/IssueCouponRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/repository/IssueCouponRepository.java
@@ -1,0 +1,9 @@
+package intbyte4.learnsmate.issue_coupon.repository;
+
+import intbyte4.learnsmate.issue_coupon.domain.IssueCoupon;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("issueCouponRepository")
+public interface IssueCouponRepository extends CrudRepository<IssueCoupon, Long> {
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/service/IssueCouponService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/service/IssueCouponService.java
@@ -1,0 +1,10 @@
+package intbyte4.learnsmate.issue_coupon.service;
+
+import intbyte4.learnsmate.issue_coupon.domain.dto.IssueCouponDTO;
+import intbyte4.learnsmate.issue_coupon.domain.vo.request.IssueCouponRegisterRequestVO;
+
+import java.util.List;
+
+public interface IssueCouponService {
+    List<IssueCouponDTO> issueCouponsToStudents(IssueCouponRegisterRequestVO request);
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/service/IssueCouponServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/issue_coupon/service/IssueCouponServiceImpl.java
@@ -1,0 +1,69 @@
+package intbyte4.learnsmate.issue_coupon.service;
+
+import intbyte4.learnsmate.coupon.domain.entity.CouponEntity;
+import intbyte4.learnsmate.coupon.service.CouponService;
+import intbyte4.learnsmate.issue_coupon.domain.IssueCoupon;
+import intbyte4.learnsmate.issue_coupon.domain.dto.IssueCouponDTO;
+import intbyte4.learnsmate.issue_coupon.domain.vo.request.IssueCouponRegisterRequestVO;
+import intbyte4.learnsmate.issue_coupon.mapper.IssueCouponMapper;
+import intbyte4.learnsmate.issue_coupon.repository.IssueCouponRepository;
+import intbyte4.learnsmate.member.domain.entity.Member;
+import intbyte4.learnsmate.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service("issueCouponService")
+@RequiredArgsConstructor
+public class IssueCouponServiceImpl implements IssueCouponService {
+
+    private final IssueCouponRepository issueCouponRepository;
+    private final IssueCouponMapper issueCouponMapper;
+    private final MemberService memberService;
+    private final CouponService couponService;
+
+    @Override
+    public List<IssueCouponDTO> issueCouponsToStudents(IssueCouponRegisterRequestVO request) {
+        List<IssueCouponDTO> issuedCoupons = new ArrayList<>();
+        registerIssueCoupon(request, issuedCoupons);
+        return issuedCoupons;
+    }
+
+    private void registerIssueCoupon(IssueCouponRegisterRequestVO request, List<IssueCouponDTO> issuedCoupons) {
+        for (Long studentCode : request.getStudentCodes()) {
+            Member student = memberService.findByStudentCode(studentCode);
+            for (Long couponCode : request.getCouponCodes()) {
+                CouponEntity coupon = couponService.findCouponByCouponCode(couponCode);
+
+                IssueCoupon issueCoupon = getIssueCoupon(coupon, student);
+
+                issueCouponRepository.save(issueCoupon);
+                issuedCoupons.add(issueCouponMapper.toDTO(issueCoupon));
+            }
+        }
+    }
+
+    private IssueCoupon getIssueCoupon(CouponEntity coupon, Member student) {
+        String couponCategoryCode = coupon.getCouponCategory().getCouponCategoryCode();
+        String formattedDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uniqueCode = UUID.randomUUID().toString().substring(0, 8);
+        String couponIssuanceCode = String.format("C%s-%s%s", couponCategoryCode, formattedDate, uniqueCode);
+
+        IssueCoupon issueCoupon = IssueCoupon.builder()
+                .couponIssuanceCode(couponIssuanceCode)
+                .couponIssueDate(LocalDateTime.now())
+                .couponUseStatus(false)
+                .student(student)
+                .coupon(coupon)
+                .build();
+        return issueCoupon;
+    }
+
+}


### PR DESCRIPTION
## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
발급 쿠폰 등록 기능 추가되었고 캠페인에서 N명의 학생에게 M개의 쿠폰을 각각 넣어줘야 하기 때문에 해당 발급 쿠폰 코드를 등록할 때 VO는 List로 넣어져서 요청이 될 것이라 그렇게 만들었습니다. List의 크기만큼 반복하면서 일일이 넣어줄 수 있는 코드를 구현했고 메소드로 구분해놨습니다.

  <br/>

close #86 
