### PR TITLE
✨ 기능 수정: CampaignService -> editCampaign 수정

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -1,10 +1,7 @@
 package intbyte4.learnsmate.campaign.controller;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
-import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
-import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignCouponVO;
-import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignStudentVO;
-import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.request.*;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseRegisterCampaignVO;
@@ -37,9 +34,9 @@ public class CampaignController {
     @Operation(summary = "직원 - 캠페인 등록")
     @PostMapping("/register")
     public ResponseEntity<ResponseRegisterCampaignVO> createCampaign
-            (@RequestBody RequestRegisterCampaignVO requestCampaign
-                    , List<RequestFindCampaignStudentVO> requestStudentList
-                    , List<RequestFindCampaignCouponVO> requestCouponList) {
+            (@RequestBody RequestRegisterCampaignVO requestCampaign,
+             @RequestBody List<RequestFindCampaignStudentVO> requestStudentList,
+             @RequestBody List<RequestFindCampaignCouponVO> requestCouponList) {
         List<MemberDTO> studentDTOList = requestStudentList.stream()
                 .map(memberMapper::fromRequestFindCampaignStudentVOToMemberDTO)
                 .toList();
@@ -49,17 +46,32 @@ public class CampaignController {
                 .toList();
 
         CampaignDTO campaignDTO = campaignService.registerCampaign(campaignMapper
-                .fromRegisterRequestVOtoDTO(requestCampaign), studentDTOList, couponDTOList);
+                .fromRegisterRequestVOtoDTO(requestCampaign)
+                , studentDTOList
+                , couponDTOList);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(campaignMapper.fromDtoToRegisterResponseVO(campaignDTO));
     }
 
     @Operation(summary = "직원 - 예약된 캠페인 수정")
     @PutMapping("/edit/{campaignCode}")
-    public ResponseEntity<ResponseEditCampaignVO> updateCampaign(@RequestBody RequestEditCampaignVO request
-            , @PathVariable("campaignCode") Long campaignCode) {
-        CampaignDTO campaignDTO = campaignService.editCampaign(campaignMapper.fromEditRequestVOtoDTO(request)
-                , campaignCode);
+    public ResponseEntity<ResponseEditCampaignVO> updateCampaign
+            (@RequestBody RequestEditCampaignVO requestCampaign,
+             @RequestBody List<RequestEditCampaignStudentVO> requestStudentList,
+             @RequestBody List<RequestEditCampaignCouponVO> requestCouponList) {
+        List<MemberDTO> studentDTOList = requestStudentList.stream()
+                .map(memberMapper::fromRequestEditCampaignStudentVOToMemberDTO)
+                .toList();
+
+        List<CouponDTO> couponDTOList = requestCouponList.stream()
+                .map(couponMapper::fromRequestEditCampaignCouponVOToCouponDTO)
+                .toList();
+
+        CampaignDTO campaignDTO = campaignService.editCampaign(campaignMapper
+                .fromEditRequestVOtoDTO(requestCampaign)
+                , studentDTOList
+                , couponDTOList);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(campaignMapper.fromDtoToEditResponseVO(campaignDTO));
     }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignCouponVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignCouponVO.java
@@ -1,0 +1,51 @@
+package intbyte4.learnsmate.campaign.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class RequestEditCampaignCouponVO {
+    @JsonProperty("coupon_code")
+    private String couponCode;
+
+    @JsonProperty("coupon_name")
+    private String couponName;
+
+    @JsonProperty("coupon_contents")
+    private String couponContents;
+
+    @JsonProperty("coupon_discount_rate")
+    private int couponDiscountRate;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("coupon_start_date")
+    private LocalDateTime couponStartDate;
+
+    @JsonProperty("coupon_expire_date")
+    private LocalDateTime couponExpireDate;
+
+    @JsonProperty("coupon_flag")
+    private Boolean couponFlag;
+
+    @JsonProperty("coupon_category_code")
+    private int couponCategoryCode;
+
+    @JsonProperty("admin_code")
+    private Long adminCode;
+
+    @JsonProperty("tutor_code")
+    private Long tutorCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignStudentVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/request/RequestEditCampaignStudentVO.java
@@ -1,0 +1,55 @@
+package intbyte4.learnsmate.campaign.domain.vo.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import intbyte4.learnsmate.member.domain.MemberType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class RequestEditCampaignStudentVO {
+    @JsonProperty("member_code")
+    private Long memberCode;
+
+    @JsonProperty("member_type")
+    private MemberType memberType;
+
+    @JsonProperty("member_email")
+    private String memberEmail;
+
+    @JsonProperty("member_password")
+    private String memberPassword;
+
+    @JsonProperty("member_name")
+    private String memberName;
+
+    @JsonProperty("member_age")
+    private Integer memberAge;
+
+    @JsonProperty("member_phone")
+    private String memberPhone;
+
+    @JsonProperty("member_address")
+    private String memberAddress;
+
+    @JsonProperty("member_birth")
+    private LocalDateTime memberBirth;
+
+    @JsonProperty("member_flag")
+    private Boolean memberFlag;
+
+    @JsonProperty("member_dormant_status")
+    private Boolean memberDormantStatus;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -10,7 +10,9 @@ public interface CampaignService {
     CampaignDTO registerCampaign(CampaignDTO requestCampaign
             , List<MemberDTO> requestStudentList
             , List<CouponDTO> requestCouponList);
-    CampaignDTO editCampaign(CampaignDTO request, Long campaignCode);
+    CampaignDTO editCampaign(CampaignDTO requestCampaign
+            , List<MemberDTO> requestStudentList
+            , List<CouponDTO> requestCouponList);
     void removeCampaign(CampaignDTO request);
     List<CampaignDTO> findAllCampaigns();
     CampaignDTO findCampaign(CampaignDTO request);

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -13,9 +13,11 @@ import intbyte4.learnsmate.common.exception.CommonException;
 import intbyte4.learnsmate.common.exception.StatusEnum;
 import intbyte4.learnsmate.coupon.domain.dto.CouponDTO;
 import intbyte4.learnsmate.coupon.service.CouponService;
+import intbyte4.learnsmate.couponbycampaign.domain.dto.CouponByCampaignDTO;
 import intbyte4.learnsmate.couponbycampaign.service.CouponByCampaignService;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.member.service.MemberService;
+import intbyte4.learnsmate.userpercampaign.domain.dto.UserPerCampaignDTO;
 import intbyte4.learnsmate.userpercampaign.service.UserPerCampaignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -82,22 +84,81 @@ public class CampaignServiceImpl implements CampaignService {
     }
 
     @Override
-    public CampaignDTO editCampaign(CampaignDTO request, Long campaignCode) {
-        if (campaignCode == null) {
+    public CampaignDTO editCampaign(CampaignDTO requestCampaign
+            , List<MemberDTO> requestStudentList
+            , List<CouponDTO> requestCouponList) {
+        if (requestCampaign.getCampaignCode() == null) {
             throw new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND);
         }
-        if (Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+        if (Objects.equals(requestCampaign.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
             throw new CommonException(StatusEnum.UPDATE_NOT_ALLOWED);
         }
 
-        AdminDTO adminDTO = adminService.findByAdminCode(request.getAdminCode());
+        AdminDTO adminDTO = adminService.findByAdminCode(requestCampaign.getAdminCode());
         Admin admin = adminDTO.convertToEntity();
 
-        Campaign updatedCampaign = campaignMapper.toEntity(request, admin);
+        Campaign updatedCampaign = campaignMapper.toEntity(requestCampaign, admin);
 
         campaignRepository.save(updatedCampaign);
 
+        editStudent(requestCampaign, requestStudentList, updatedCampaign);
+
+        editCoupon(requestCampaign, requestCouponList, updatedCampaign);
+
         return campaignMapper.toDTO(updatedCampaign);
+    }
+
+    private void editCoupon(CampaignDTO requestCampaign
+            , List<CouponDTO> requestCouponList
+            , Campaign updatedCampaign) {
+        List<CouponByCampaignDTO> existingCouponList = couponByCampaignService
+                .findByCampaignCode(updatedCampaign);
+
+        List<CouponByCampaignDTO> couponsToRemove = existingCouponList.stream()
+                .filter(coupon -> requestCouponList.stream()
+                        .noneMatch(newCoupon -> newCoupon.getCouponCode().equals(coupon.getCouponCode())))
+                .toList();
+
+        List<CouponDTO> couponsToAdd = requestCouponList.stream()
+                .filter(newCoupon -> existingCouponList.stream()
+                        .noneMatch(coupon -> coupon.getCouponCode().equals(newCoupon.getCouponCode())))
+                .toList();
+
+        couponsToRemove.forEach(coupon -> couponByCampaignService
+                .removeCouponByCampaign(coupon.getCouponByCampaignCode()));
+
+        couponsToAdd.forEach(couponDTO -> {
+            CouponDTO newCoupon = couponService.findCouponByCouponCode(couponDTO.getCouponCode());
+            if (newCoupon == null) throw new CommonException(StatusEnum.COUPON_NOT_FOUND);
+            couponByCampaignService.registerCouponByCampaign(newCoupon, requestCampaign);
+        });
+    }
+
+    private void editStudent(CampaignDTO requestCampaign
+            , List<MemberDTO> requestStudentList
+            , Campaign updatedCampaign) {
+        List<UserPerCampaignDTO> existingStudentList = userPerCampaignService
+                .findByCampaignCode(updatedCampaign);
+
+        List<UserPerCampaignDTO> studentsToRemove = existingStudentList.stream()
+                .filter(student -> requestStudentList.stream()
+                        .noneMatch(newStudent -> newStudent.getMemberCode().equals(student.getStudentCode())))
+                .toList();
+
+        List<MemberDTO> studentsToAdd = requestStudentList.stream()
+                .filter(newStudent -> existingStudentList.stream()
+                        .noneMatch(student -> student.getStudentCode().equals(newStudent.getMemberCode())))
+                .toList();
+
+        studentsToRemove.forEach(student -> userPerCampaignService
+                .removeUserPerCampaign(student.getUserPerCampaignCode()));
+
+        studentsToAdd.forEach(memberDTO -> {
+            MemberDTO newStudent = memberService.findMemberByMemberCode(memberDTO.getMemberCode()
+                    ,memberDTO.getMemberType());
+            if (newStudent == null) throw new CommonException(StatusEnum.STUDENT_NOT_FOUND);
+            userPerCampaignService.registerUserPerCampaign(newStudent, requestCampaign);
+        });
     }
 
     @Override

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/coupon/mapper/CouponMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/coupon/mapper/CouponMapper.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.coupon.mapper;
 
+import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignCouponVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignCouponVO;
 import intbyte4.learnsmate.coupon.domain.dto.CouponDTO;
 import intbyte4.learnsmate.coupon.domain.entity.CouponEntity;
@@ -98,6 +99,23 @@ public class CouponMapper {
     }
 
     public CouponDTO fromRequestFindCampaignCouponVOToCouponDTO(RequestFindCampaignCouponVO request) {
+        return CouponDTO.builder()
+                .couponCode(request.getCouponCode())
+                .couponName(request.getCouponName())
+                .couponContents(request.getCouponContents())
+                .couponDiscountRate(request.getCouponDiscountRate())
+                .createdAt(request.getCreatedAt())
+                .updatedAt(request.getUpdatedAt())
+                .couponStartDate(request.getCouponStartDate())
+                .couponExpireDate(request.getCouponExpireDate())
+                .couponFlag(true)
+                .couponCategoryCode(request.getCouponCategoryCode())
+                .adminCode(request.getAdminCode())
+                .tutorCode(request.getTutorCode())
+                .build();
+    }
+
+    public CouponDTO fromRequestEditCampaignCouponVOToCouponDTO(RequestEditCampaignCouponVO request) {
         return CouponDTO.builder()
                 .couponCode(request.getCouponCode())
                 .couponName(request.getCouponName())

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/mapper/CouponByCampaignMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/mapper/CouponByCampaignMapper.java
@@ -1,0 +1,30 @@
+package intbyte4.learnsmate.couponbycampaign.mapper;
+
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
+import intbyte4.learnsmate.coupon.domain.entity.CouponEntity;
+import intbyte4.learnsmate.couponbycampaign.domain.dto.CouponByCampaignDTO;
+import intbyte4.learnsmate.couponbycampaign.domain.entity.CouponByCampaign;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponByCampaignMapper {
+
+    public CouponByCampaignDTO toDTO(CouponByCampaign entity) {
+        return CouponByCampaignDTO.builder()
+                .couponByCampaignCode(entity.getCouponByCampaignCode())
+                .CouponCode(entity.getCoupon().getCouponCode())
+                .CampaignCode(entity.getCampaign().getCampaignCode())
+                .build();
+    }
+
+    public CouponByCampaign toEntity(CouponByCampaignDTO dto, CouponEntity coupon, Campaign campaign) {
+        return CouponByCampaign.builder()
+                .couponByCampaignCode(dto.getCouponByCampaignCode())
+                .coupon(coupon)
+                .campaign(campaign)
+                .build();
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/repository/CouponByCampaignRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/repository/CouponByCampaignRepository.java
@@ -1,9 +1,13 @@
 package intbyte4.learnsmate.couponbycampaign.repository;
 
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.couponbycampaign.domain.entity.CouponByCampaign;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CouponByCampaignRepository extends JpaRepository<CouponByCampaign, Long> {
+    List<CouponByCampaign> findByCampaign(Campaign getCampaignCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/service/CouponByCampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/service/CouponByCampaignService.java
@@ -1,8 +1,14 @@
 package intbyte4.learnsmate.couponbycampaign.service;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.coupon.domain.dto.CouponDTO;
+import intbyte4.learnsmate.couponbycampaign.domain.dto.CouponByCampaignDTO;
+
+import java.util.List;
 
 public interface CouponByCampaignService {
     void registerCouponByCampaign(CouponDTO coupon, CampaignDTO campaign);
+    List<CouponByCampaignDTO> findByCampaignCode(Campaign updatedCampaign);
+    void removeCouponByCampaign(Long couponByCampaignCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/service/CouponByCampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/couponbycampaign/service/CouponByCampaignServiceImpl.java
@@ -4,15 +4,21 @@ import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.coupon.domain.dto.CouponDTO;
 import intbyte4.learnsmate.coupon.domain.entity.CouponEntity;
+import intbyte4.learnsmate.couponbycampaign.domain.dto.CouponByCampaignDTO;
 import intbyte4.learnsmate.couponbycampaign.domain.entity.CouponByCampaign;
+import intbyte4.learnsmate.couponbycampaign.mapper.CouponByCampaignMapper;
 import intbyte4.learnsmate.couponbycampaign.repository.CouponByCampaignRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CouponByCampaignServiceImpl implements CouponByCampaignService{
     private final CouponByCampaignRepository couponByCampaignRepository;
+    private final CouponByCampaignMapper couponByCampaignMapper;
 
     @Override
     public void registerCouponByCampaign(CouponDTO coupon, CampaignDTO campaign) {
@@ -31,5 +37,27 @@ public class CouponByCampaignServiceImpl implements CouponByCampaignService{
                 .build();
 
         couponByCampaignRepository.save(couponByCampaign);
+    }
+
+    @Override
+    public List<CouponByCampaignDTO> findByCampaignCode(Campaign campaign) {
+        Campaign getCampaignCode = Campaign.builder()
+                .campaignCode(campaign.getCampaignCode())
+                .build();
+
+        List<CouponByCampaign> couponByCampaignList = couponByCampaignRepository.findByCampaign(getCampaignCode);
+
+        return couponByCampaignList.stream()
+                .map(couponByCampaignMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void removeCouponByCampaign(Long couponByCampaignCode) {
+        CouponByCampaign getCouponByCampaignCode = CouponByCampaign.builder()
+                .couponByCampaignCode(couponByCampaignCode)
+                .build();
+
+        couponByCampaignRepository.delete(getCouponByCampaignCode);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/member/mapper/MemberMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/member/mapper/MemberMapper.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.member.mapper;
 
+import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignStudentVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestFindCampaignStudentVO;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.member.domain.entity.Member;
@@ -105,6 +106,24 @@ public class MemberMapper{
     }
 
     public MemberDTO fromRequestFindCampaignStudentVOToMemberDTO(RequestFindCampaignStudentVO request) {
+        return MemberDTO.builder()
+                .memberCode(request.getMemberCode())
+                .memberType(request.getMemberType())
+                .memberEmail(request.getMemberEmail())
+//                .memberPassword(request.getMemberPassword()) // 필요 시 비밀번호 포함
+                .memberName(request.getMemberName())
+                .memberAge(request.getMemberAge())
+                .memberPhone(request.getMemberPhone())
+                .memberAddress(request.getMemberAddress())
+                .memberBirth(request.getMemberBirth())
+                .memberFlag(request.getMemberFlag())
+                .memberDormantStatus(request.getMemberDormantStatus())
+                .createdAt(request.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public MemberDTO fromRequestEditCampaignStudentVOToMemberDTO(RequestEditCampaignStudentVO request) {
         return MemberDTO.builder()
                 .memberCode(request.getMemberCode())
                 .memberType(request.getMemberType())

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/repository/UserPerCampaignRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/repository/UserPerCampaignRepository.java
@@ -1,9 +1,13 @@
 package intbyte4.learnsmate.userpercampaign.repository;
 
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.userpercampaign.domain.entity.UserPerCampaign;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserPerCampaignRepository extends JpaRepository<UserPerCampaign, Long> {
+    List<UserPerCampaign> findByCampaign(Campaign campaign);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/service/UserPerCampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/service/UserPerCampaignService.java
@@ -1,9 +1,14 @@
 package intbyte4.learnsmate.userpercampaign.service;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
+import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
+import intbyte4.learnsmate.userpercampaign.domain.dto.UserPerCampaignDTO;
+
+import java.util.List;
 
 public interface UserPerCampaignService {
     void registerUserPerCampaign(MemberDTO member, CampaignDTO campaign);
-
+    List<UserPerCampaignDTO> findByCampaignCode(Campaign campaign);
+    void removeUserPerCampaign(Long userPerCampaignCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/service/UserPerCampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/userpercampaign/service/UserPerCampaignServiceImpl.java
@@ -4,15 +4,21 @@ import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
 import intbyte4.learnsmate.campaign.domain.entity.Campaign;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.member.domain.entity.Member;
+import intbyte4.learnsmate.userpercampaign.domain.dto.UserPerCampaignDTO;
 import intbyte4.learnsmate.userpercampaign.domain.entity.UserPerCampaign;
+import intbyte4.learnsmate.userpercampaign.mapper.UserPerCampaignMapper;
 import intbyte4.learnsmate.userpercampaign.repository.UserPerCampaignRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class UserPerCampaignServiceImpl implements UserPerCampaignService{
     private final UserPerCampaignRepository userPerCampaignRepository;
+    private final UserPerCampaignMapper userPerCampaignMapper;
 
     @Override
     public void registerUserPerCampaign(MemberDTO member, CampaignDTO campaign) {
@@ -31,5 +37,27 @@ public class UserPerCampaignServiceImpl implements UserPerCampaignService{
                 .build();
 
         userPerCampaignRepository.save(userPerCampaign);
+    }
+
+    @Override
+    public List<UserPerCampaignDTO> findByCampaignCode(Campaign campaign) {
+        Campaign getCampaignCode = Campaign.builder()
+                .campaignCode(campaign.getCampaignCode())
+                .build();
+
+        List<UserPerCampaign> userPerCampaignList = userPerCampaignRepository.findByCampaign(getCampaignCode);
+
+        return userPerCampaignList.stream()
+                .map(userPerCampaignMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void removeUserPerCampaign(Long userPerCampaignCode) {
+        UserPerCampaign getUserPerCampaignCode = UserPerCampaign.builder()
+                .userPerCampaignCode(userPerCampaignCode)
+                .build();
+
+        userPerCampaignRepository.delete(getUserPerCampaignCode);
     }
 }


### PR DESCRIPTION
- 제목 : feat(#99 ):  editCampaign 수정

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기존 캠페인 제목, 내용, 발송 시간만 수정 가능하던 기능에서 학생, 쿠폰도 수정 가능하게 변경했습니다.

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 제목으로 조회

  <br/>
