### PR TITLE
✨ 기능 추가 / 수정: 학생, 강사 예비 블랙리스트 단건 조회 메서드 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
@@ -117,4 +117,17 @@ public class BlacklistController {
 
         return ResponseEntity.status(HttpStatus.OK).body(voList);
     }
+
+    // 강사 예비 블랙리스트 단건 조회
+    @GetMapping("/tutor/reserved/{tutorcode}")
+    public ResponseEntity<List<ResponseFindReservedBlacklistOneVO>> findTutorReservedBlacklist(@PathVariable("tutorcode") Long tutorCode) {
+        // 결국 예비 블랙리스트가 없어서 계산해서 가져와야함. -> Report에서 tutorcode에 해당하는 모든 Report 가져오고
+        // -> 그 report 안에 있는 comment code를 통해서 comment도 가져와야함.
+        List<BlacklistReportCommentDTO> dtoList = blacklistService.findMemberReservedBlacklist(tutorCode);
+
+        List<ResponseFindReservedBlacklistOneVO> voList
+                = blacklistMapper.fromBlacklistReportCommentDTOToResponseFindReservedBlacklistOneVO(dtoList);
+
+        return ResponseEntity.status(HttpStatus.OK).body(voList);
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
@@ -65,7 +65,7 @@ public class BlacklistController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    // 직원 - 예비 블랙리스트 조회(학생)
+    // 직원 - 예비 블랙리스트 전체 조회(학생)
     @GetMapping("/student/reserved")
     public ResponseEntity<List<ResponseFindReservedStudentBlacklistVO>> findAllStudentReservedBlacklist() {
         // dto로 받아와야하는데 어떤 dto로 받아올까?
@@ -83,6 +83,7 @@ public class BlacklistController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    // 직원 - 예비 블랙리스트 전체 조회(강사)
     @GetMapping("/tutor/reserved")
     public ResponseEntity<List<ResponseFindReservedTutorBlacklistVO>> findAllTutorReservedBlacklist(){
         // dto로 받아와야하는데 어떤 dto로 받아올까?

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/controller/BlacklistController.java
@@ -1,7 +1,9 @@
 package intbyte4.learnsmate.blacklist.controller;
 
 import intbyte4.learnsmate.blacklist.domain.dto.BlacklistDTO;
+import intbyte4.learnsmate.blacklist.domain.dto.BlacklistReportCommentDTO;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReportVO;
+import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedBlacklistOneVO;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedStudentBlacklistVO;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedTutorBlacklistVO;
 import intbyte4.learnsmate.blacklist.mapper.BlacklistMapper;
@@ -12,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -100,5 +103,18 @@ public class BlacklistController {
             );
         }
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 학생 예비 블랙리스트 단건 조회
+    @GetMapping("/student/reserved/{studentcode}")
+    public ResponseEntity<List<ResponseFindReservedBlacklistOneVO>> findStudentReservedBlacklist(@PathVariable("studentcode") Long studentCode) {
+        // 결국 예비 블랙리스트가 없어서 계산해서 가져와야함. -> Report에서 tutorcode에 해당하는 모든 Report 가져오고
+        // -> 그 report 안에 있는 comment code를 통해서 comment도 가져와야함.
+        List<BlacklistReportCommentDTO> dtoList = blacklistService.findMemberReservedBlacklist(studentCode);
+
+        List<ResponseFindReservedBlacklistOneVO> voList
+                = blacklistMapper.fromBlacklistReportCommentDTOToResponseFindReservedBlacklistOneVO(dtoList);
+
+        return ResponseEntity.status(HttpStatus.OK).body(voList);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/domain/dto/BlacklistReportCommentDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/domain/dto/BlacklistReportCommentDTO.java
@@ -1,0 +1,15 @@
+package intbyte4.learnsmate.blacklist.domain.dto;
+
+import intbyte4.learnsmate.comment.domain.dto.CommentDTO;
+import intbyte4.learnsmate.report.domain.dto.ReportDTO;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BlacklistReportCommentDTO {
+    private ReportDTO reportDTO;
+    private CommentDTO commentDTO;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/domain/vo/response/ResponseFindReservedBlacklistOneVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/domain/vo/response/ResponseFindReservedBlacklistOneVO.java
@@ -1,0 +1,16 @@
+package intbyte4.learnsmate.blacklist.domain.vo.response;
+
+import intbyte4.learnsmate.comment.domain.dto.CommentDTO;
+import intbyte4.learnsmate.report.domain.dto.ReportDTO;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class ResponseFindReservedBlacklistOneVO {
+
+    private ReportDTO reportDTO;
+    private CommentDTO commentDTO;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/mapper/BlacklistMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/mapper/BlacklistMapper.java
@@ -1,12 +1,17 @@
 package intbyte4.learnsmate.blacklist.mapper;
 
 import intbyte4.learnsmate.blacklist.domain.dto.BlacklistDTO;
+import intbyte4.learnsmate.blacklist.domain.dto.BlacklistReportCommentDTO;
 import intbyte4.learnsmate.blacklist.domain.entity.Blacklist;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReportVO;
+import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedBlacklistOneVO;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedStudentBlacklistVO;
 import intbyte4.learnsmate.blacklist.domain.vo.response.ResponseFindReservedTutorBlacklistVO;
 import intbyte4.learnsmate.report.domain.dto.ReportedMemberDTO;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class BlacklistMapper {
@@ -50,5 +55,14 @@ public class BlacklistMapper {
                 .memberName(dto.getReportedMember().getMemberName())
                 .reportCount(dto.getReportCount())
                 .build();
+    }
+
+    public List<ResponseFindReservedBlacklistOneVO> fromBlacklistReportCommentDTOToResponseFindReservedBlacklistOneVO(List<BlacklistReportCommentDTO> dtoList) {
+        return dtoList.stream()
+                .map(dto -> ResponseFindReservedBlacklistOneVO.builder()
+                        .reportDTO(dto.getReportDTO())
+                        .commentDTO(dto.getCommentDTO())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/service/BlacklistService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/blacklist/service/BlacklistService.java
@@ -1,11 +1,15 @@
 package intbyte4.learnsmate.blacklist.service;
 
 import intbyte4.learnsmate.blacklist.domain.dto.BlacklistDTO;
+import intbyte4.learnsmate.blacklist.domain.dto.BlacklistReportCommentDTO;
 import intbyte4.learnsmate.blacklist.domain.entity.Blacklist;
 import intbyte4.learnsmate.blacklist.mapper.BlacklistMapper;
 import intbyte4.learnsmate.blacklist.repository.BlacklistRepository;
+import intbyte4.learnsmate.comment.domain.dto.CommentDTO;
+import intbyte4.learnsmate.comment.service.CommentService;
 import intbyte4.learnsmate.member.domain.MemberType;
 import intbyte4.learnsmate.member.service.MemberService;
+import intbyte4.learnsmate.report.domain.dto.ReportDTO;
 import intbyte4.learnsmate.report.domain.dto.ReportedMemberDTO;
 import intbyte4.learnsmate.report.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class BlacklistService {
@@ -21,13 +26,15 @@ public class BlacklistService {
     private final BlacklistMapper blacklistMapper;
     private final ReportService reportService;
     private final MemberService memberService;
+    private final CommentService commentService;
 
     @Autowired
-    public BlacklistService(BlacklistRepository blacklistRepository, BlacklistMapper blacklistMapper, ReportService reportService, MemberService memberService) {
+    public BlacklistService(BlacklistRepository blacklistRepository, BlacklistMapper blacklistMapper, ReportService reportService, MemberService memberService, CommentService commentService) {
         this.blacklistRepository = blacklistRepository;
         this.blacklistMapper = blacklistMapper;
         this.reportService = reportService;
         this.memberService = memberService;
+        this.commentService = commentService;
     }
 
     // 1. flag는 볼필요 없음. -> 학생, 강사만 구분해야함.
@@ -57,5 +64,27 @@ public class BlacklistService {
         List<ReportedMemberDTO> reportedMoreThanFiveMemberList = reportService.findReportCountByMemberCode();
 
         return reportedMoreThanFiveMemberList;
+    }
+
+    // 신고당한 댓글 내역까지 모두 볼수 있는 서비스 메서드
+    public List<BlacklistReportCommentDTO> findMemberReservedBlacklist(Long memberCode) {
+
+        // 1. Report table에서 memberCode와 reportedMemberCode 가 같은거 가져오기
+        List<ReportDTO> reportDTOlist = reportService.findAllReportByMemberCode(memberCode);
+
+        // 2. ReportDTO의 comment_code 내역 가져오기 -> comment table
+        List<CommentDTO> commentDTOList = reportDTOlist.stream()
+                .map(reportDTO -> commentService.findComentByCommentCode(reportDTO.getCommentCode()))
+                .collect(Collectors.toList());
+
+        // 3. List<BlacklistReportCommentDTO> 생성 및 데이터 추가
+        List<BlacklistReportCommentDTO> blacklistReportCommentDTOList = new ArrayList<>();
+        for (int i = 0; i < reportDTOlist.size(); i++) {
+            blacklistReportCommentDTOList.add(BlacklistReportCommentDTO.builder()
+                    .reportDTO(reportDTOlist.get(i))
+                    .commentDTO(commentDTOList.get(i))
+                    .build());
+        }
+        return blacklistReportCommentDTOList;
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/report/repository/ReportRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/report/repository/ReportRepository.java
@@ -1,6 +1,5 @@
 package intbyte4.learnsmate.report.repository;
 
-import intbyte4.learnsmate.member.domain.entity.Member;
 import intbyte4.learnsmate.report.domain.dto.ReportedMemberDTO;
 import intbyte4.learnsmate.report.domain.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +14,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     @Query("SELECT new intbyte4.learnsmate.report.domain.dto.ReportedMemberDTO(r.reportedMember, COUNT(r)) " +
             "FROM report r GROUP BY r.reportedMember HAVING COUNT(r) >= 5")
     List<ReportedMemberDTO> findMembersWithReportsCountGreaterThanEqualFive();
+
+    // 신고 당한 멤버의 멤버코드가 파라미터와 일치하는 신고 리스트
+    List<Report> findByReportedMember_MemberCode(Long memberCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/report/service/ReportService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/report/service/ReportService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ReportService {
@@ -51,5 +52,14 @@ public class ReportService {
                 = reportRepository.findMembersWithReportsCountGreaterThanEqualFive();
 
         return reportedMoreThanFiveMemberList;
+    }
+
+    // memberCode로 신고당한 모든 신고내역 조회
+    public List<ReportDTO> findAllReportByMemberCode(Long memberCode) {
+        List<Report> reportList = reportRepository.findByReportedMember_MemberCode(memberCode);
+
+        return reportList.stream()
+                    .map(reportMapper::fromReportToReportDTO)
+                    .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- 제목 : feat(#100 ): 기능명 ✨ 기능 추가 / 수정: 학생, 강사 예비 블랙리스트 단건 조회 메서드 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
학생, 강사 예비 블랙리스트를 조회하는 메서드를 구현했습니다.
신고내역이 5회 이상인 멤버가 예비 블랙리스트로 처리되는데 
이때, 단건 조회시 신고내역과 어떤 댓글로 신고를 당했는지 확인하기 위해서 report, comment service를 사용했습니다.

  <br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
예비 블랙리스트를 따로 테이블로 빼도 괜찮을거 같다는 생각을 했습니다.
  <br/>

close #100 