### PR TITLE
✨ 기능 추가: CampaignService -> findCampaignsByType 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -1,8 +1,10 @@
 package intbyte4.learnsmate.campaign.controller;
 
 import intbyte4.learnsmate.campaign.domain.dto.CampaignDTO;
+import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
 import intbyte4.learnsmate.campaign.domain.vo.request.*;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignByTypeVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.mapper.CampaignMapper;
@@ -100,5 +102,18 @@ public class CampaignController {
         CampaignDTO campaignDTO = campaignService.findCampaign(getCampaignCode);
 
         return ResponseEntity.status(HttpStatus.OK).body(campaignMapper.fromDtoToFindResponseVO(campaignDTO));
+    }
+
+    @Operation(summary = "직원 - 캠페인 타입별 조회")
+    @GetMapping("/type/{campaignType}")
+    public ResponseEntity<List<ResponseFindCampaignByTypeVO>> getCampaignsByType
+            (@PathVariable String campaignType){
+        CampaignDTO getCampaignCode = new CampaignDTO();
+        getCampaignCode.setCampaignType(campaignType);
+        List<CampaignDTO> campaignDTOList = campaignService.findCampaignsByType(getCampaignCode);
+        List<ResponseFindCampaignByTypeVO> responseFindCampaignByTypeVOList = campaignMapper
+                .fromDtoListToFindCampaignByTypeVO(campaignDTOList);
+
+        return new ResponseEntity<>(responseFindCampaignByTypeVOList, HttpStatus.OK);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseFindCampaignByTypeVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/domain/vo/response/ResponseFindCampaignByTypeVO.java
@@ -1,0 +1,37 @@
+package intbyte4.learnsmate.campaign.domain.vo.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ResponseFindCampaignByTypeVO {
+    @JsonProperty("campaign_code")
+    private Long campaignCode;
+
+    @JsonProperty("campaign_title")
+    private String campaignTitle;
+
+    @JsonProperty("campaign_contents")
+    private String campaignContents;
+
+    @JsonProperty("campaign_type")
+    private String campaignType;
+
+    @JsonProperty("campaign_send_date")
+    private LocalDateTime campaignSendDate;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("admin_code")
+    private Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/mapper/CampaignMapper.java
@@ -8,6 +8,7 @@ import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestEditCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.request.RequestRegisterCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseEditCampaignVO;
+import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignByTypeVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseFindCampaignVO;
 import intbyte4.learnsmate.campaign.domain.vo.response.ResponseRegisterCampaignVO;
 import lombok.RequiredArgsConstructor;
@@ -117,4 +118,16 @@ public class CampaignMapper {
                 .build();
     }
 
+    public List<ResponseFindCampaignByTypeVO> fromDtoListToFindCampaignByTypeVO(List<CampaignDTO> dtoList) {
+        return dtoList.stream().map(dto -> ResponseFindCampaignByTypeVO.builder()
+                .campaignCode(dto.getCampaignCode())
+                .campaignTitle(dto.getCampaignTitle())
+                .campaignContents(dto.getCampaignContents())
+                .campaignType(dto.getCampaignType())
+                .campaignSendDate(dto.getCampaignSendDate())
+                .createdAt(dto.getCreatedAt())
+                .updatedAt(dto.getUpdatedAt())
+                .adminCode(dto.getAdminCode())
+                .build()).collect(Collectors.toList());
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/repository/CampaignRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/repository/CampaignRepository.java
@@ -1,9 +1,13 @@
 package intbyte4.learnsmate.campaign.repository;
 
 import intbyte4.learnsmate.campaign.domain.entity.Campaign;
+import intbyte4.learnsmate.campaign.domain.entity.CampaignTypeEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
+    List<Campaign> findByCampaignType(CampaignTypeEnum campaignType);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignService.java
@@ -16,4 +16,5 @@ public interface CampaignService {
     void removeCampaign(CampaignDTO request);
     List<CampaignDTO> findAllCampaigns();
     CampaignDTO findCampaign(CampaignDTO request);
+    List<CampaignDTO> findCampaignsByType(CampaignDTO request);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -50,7 +50,7 @@ public class CampaignServiceImpl implements CampaignService {
         AdminDTO adminDTO = adminService.findByAdminCode(requestCampaign.getAdminCode());
         Admin admin = adminMapper.toEntity(adminDTO);
 
-        if (Objects.equals(requestCampaign.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+        if (Objects.equals(requestCampaign.getCampaignType(), CampaignTypeEnum.INSTANT.getType())) {
             sendTime = LocalDateTime.now();
         } else {
             sendTime = requestCampaign.getCampaignSendDate();
@@ -71,7 +71,7 @@ public class CampaignServiceImpl implements CampaignService {
 
         requestStudentList.forEach(memberDTO -> {
             MemberDTO foundStudent = memberService.findMemberByMemberCode(memberDTO.getMemberCode()
-                    ,memberDTO.getMemberType());
+                    , memberDTO.getMemberType());
             if (foundStudent == null) throw new CommonException(StatusEnum.STUDENT_NOT_FOUND);
             userPerCampaignService.registerUserPerCampaign(foundStudent, requestCampaign);
         });
@@ -92,7 +92,7 @@ public class CampaignServiceImpl implements CampaignService {
         if (requestCampaign.getCampaignCode() == null) {
             throw new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND);
         }
-        if (Objects.equals(requestCampaign.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+        if (Objects.equals(requestCampaign.getCampaignType(), CampaignTypeEnum.INSTANT.getType())) {
             throw new CommonException(StatusEnum.UPDATE_NOT_ALLOWED);
         }
 
@@ -157,17 +157,17 @@ public class CampaignServiceImpl implements CampaignService {
 
         studentsToAdd.forEach(memberDTO -> {
             MemberDTO newStudent = memberService.findMemberByMemberCode(memberDTO.getMemberCode()
-                    ,memberDTO.getMemberType());
+                    , memberDTO.getMemberType());
             if (newStudent == null) throw new CommonException(StatusEnum.STUDENT_NOT_FOUND);
             userPerCampaignService.registerUserPerCampaign(newStudent, requestCampaign);
         });
     }
 
     @Override
-    public void removeCampaign(CampaignDTO request){
+    public void removeCampaign(CampaignDTO request) {
         Campaign campaign = campaignRepository.findById(request.getCampaignCode())
                 .orElseThrow(() -> new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND));
-        if(Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType())){
+        if (Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType())) {
             throw new CommonException(StatusEnum.DELETE_NOT_ALLOWED);
         }
 
@@ -175,18 +175,32 @@ public class CampaignServiceImpl implements CampaignService {
     }
 
     @Override
-    public List<CampaignDTO> findAllCampaigns(){
+    public List<CampaignDTO> findAllCampaigns() {
         List<Campaign> campaign = campaignRepository.findAll();
         List<CampaignDTO> campaignDTOList = new ArrayList<>();
-        campaign.forEach(dto -> campaignDTOList.add(campaignMapper.toDTO(dto)));
+        campaign.forEach(entity -> campaignDTOList.add(campaignMapper.toDTO(entity)));
 
         return campaignDTOList;
     }
 
     @Override
-    public CampaignDTO findCampaign(CampaignDTO request){
+    public CampaignDTO findCampaign(CampaignDTO request) {
         Campaign campaign = campaignRepository.findById(request.getCampaignCode())
                 .orElseThrow(() -> new CommonException(StatusEnum.CAMPAIGN_NOT_FOUND));
         return campaignMapper.toDTO(campaign);
+    }
+
+    @Override
+    public List<CampaignDTO> findCampaignsByType(CampaignDTO request) {
+        CampaignTypeEnum getCampaignType;
+        if (Objects.equals(request.getCampaignType(), CampaignTypeEnum.INSTANT.getType()))
+            getCampaignType = CampaignTypeEnum.INSTANT;
+        else getCampaignType = CampaignTypeEnum.RESERVATION;
+
+        List<Campaign> campaignList = campaignRepository.findByCampaignType(getCampaignType);
+        List<CampaignDTO> campaignDTOList = new ArrayList<>();
+        campaignList.forEach(entity -> campaignDTOList.add(campaignMapper.toDTO(entity)));
+
+        return campaignDTOList;
     }
 }


### PR DESCRIPTION
- 제목 : feat(#114 ): findCampaignsByType 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 캠페인 타입이 INSTANT이면 즉시발송만 조회, RESERVATION이면 예약발송만 조회 가능

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- 제목으로 조회, 기간별 조회

  <br/>
