### PR TITLE
✨ 기능 수정: VOCService -> countVOCByCategory 수정

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VOCController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VOCController.java
@@ -3,6 +3,7 @@ package intbyte4.learnsmate.voc.controller;
 import intbyte4.learnsmate.common.exception.CommonException;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.voc.domain.dto.VOCDTO;
+import intbyte4.learnsmate.voc.domain.vo.reqeust.RequestCountByCategoryVO;
 import intbyte4.learnsmate.voc.domain.vo.response.ResponseCountByCategoryVO;
 import intbyte4.learnsmate.voc.domain.vo.response.ResponseFindVOCVO;
 import intbyte4.learnsmate.voc.mapper.VOCMapper;
@@ -80,10 +81,12 @@ public class VOCController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "직원 - VOC 카테고리 별 개수 조회")
+    @Operation(summary = "직원 - 기간 별 VOC 카테고리 별 개수 조회")
     @GetMapping("/count-by-category")
-    public ResponseEntity<List<ResponseCountByCategoryVO>> countVOCByCategory() {
-        Map<Integer, Long> categoryCountMap = vocService.countVOCByCategory();
+    public ResponseEntity<List<ResponseCountByCategoryVO>> countVOCByCategory
+            (@RequestBody RequestCountByCategoryVO requestVO) {
+        Map<Integer, Long> categoryCountMap = vocService.countVOCByCategory
+                (requestVO.getStartDate(), requestVO.getEndDate());
         List<ResponseCountByCategoryVO> response = categoryCountMap.entrySet().stream()
                 .map(entry -> ResponseCountByCategoryVO.builder()
                         .vocCategoryCode(entry.getKey())

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/vo/reqeust/RequestCountByCategoryVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/domain/vo/reqeust/RequestCountByCategoryVO.java
@@ -1,0 +1,20 @@
+package intbyte4.learnsmate.voc.domain.vo.reqeust;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class RequestCountByCategoryVO {
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VOCRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VOCRepository.java
@@ -26,4 +26,6 @@ public interface VOCRepository extends JpaRepository<VOC, Long>, VOCRepositoryCu
     long countByVocCategoryCodeAndDateRange(@Param("vocCategoryCode") Integer vocCategoryCode,
                                             @Param("startDate") LocalDateTime startDate,
                                             @Param("endDate") LocalDateTime endDate);
+
+    long countByVocCategory_VocCategoryCode(Integer vocCategoryCode);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VOCRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/repository/VOCRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -21,5 +22,8 @@ public interface VOCRepository extends JpaRepository<VOC, Long>, VOCRepositoryCu
             "AND v.vocAnswerStatus = true")
     List<VOC> findAnsweredVOCByMember(@Param("memberCode") Long memberCode);
 
-    long countByVocCategory_VocCategoryCode(Integer vocCategoryCode);
+    @Query("SELECT COUNT(v) FROM Voc v WHERE v.vocCategory.vocCategoryCode = :vocCategoryCode AND v.createdAt BETWEEN :startDate AND :endDate")
+    long countByVocCategoryCodeAndDateRange(@Param("vocCategoryCode") Integer vocCategoryCode,
+                                            @Param("startDate") LocalDateTime startDate,
+                                            @Param("endDate") LocalDateTime endDate);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCService.java
@@ -3,6 +3,7 @@ package intbyte4.learnsmate.voc.service;
 import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.voc.domain.dto.VOCDTO;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -19,5 +20,5 @@ public interface VOCService {
 
     List<VOCDTO> filterVOC(VOCDTO vocDTO, MemberDTO memberDTO);
 
-    Map<Integer, Long> countVOCByCategory();
+    Map<Integer, Long> countVOCByCategory(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCServiceImpl.java
@@ -101,7 +101,12 @@ public class VOCServiceImpl implements VOCService {
 
         vocCategoryDTOList.forEach(category -> {
             int vocCategoryCode = category.getVocCategoryCode();
-            long count = vocRepository.countByVocCategoryCodeAndDateRange(vocCategoryCode, startDate, endDate);
+            long count;
+            if(startDate != null && endDate != null) {
+                count = vocRepository.countByVocCategoryCodeAndDateRange(vocCategoryCode, startDate, endDate);
+            } else {
+                count = vocRepository.countByVocCategory_VocCategoryCode(vocCategoryCode);
+            }
             categoryCountMap.put(vocCategoryCode, count);
         });
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/service/VOCServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -93,15 +94,15 @@ public class VOCServiceImpl implements VOCService {
     }
 
     @Override
-    public Map<Integer, Long> countVOCByCategory(){
+    public Map<Integer, Long> countVOCByCategory(LocalDateTime startDate, LocalDateTime endDate){
         List<VocCategoryDTO> vocCategoryDTOList = vocCategoryService.findAll();
 
         Map<Integer, Long> categoryCountMap = new HashMap<>();
 
         vocCategoryDTOList.forEach(category -> {
-            int categoryCode = category.getVocCategoryCode();
-            long count = vocRepository.countByVocCategory_VocCategoryCode(categoryCode);
-            categoryCountMap.put(categoryCode, count);
+            int vocCategoryCode = category.getVocCategoryCode();
+            long count = vocRepository.countByVocCategoryCodeAndDateRange(vocCategoryCode, startDate, endDate);
+            categoryCountMap.put(vocCategoryCode, count);
         });
 
         return categoryCountMap;


### PR DESCRIPTION
- 제목 : feat(#194 ): VOCService -> countVOCByCategory 수정

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기존 VOC 카테고리 별 VOC 개수 조회에서 지정된 기간 내 개수 조회가 가능하도록 수정했습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/1acd72dd-1856-40bf-9896-1684036d9340)

<br/>

## 🔧 앞으로의 과제

- 프론트엔드

  <br/>
