### PR TITLE
✨ 기능 추가 / 수정: 카테고리 별 학생 비율 그래프 메서드 작성

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/member/domain/entity/Member.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/member/domain/entity/Member.java
@@ -8,7 +8,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity(name = "member")
-@Table(name = "member")
+@Table(name = "members")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/controller/PreferredTopicsController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/controller/PreferredTopicsController.java
@@ -1,16 +1,20 @@
 package intbyte4.learnsmate.preferred_topics.controller;
 
+import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsConvertDTO;
 import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicsDTO;
 import intbyte4.learnsmate.preferred_topics.domain.vo.request.RequestSavePreferredHistoryVO;
+import intbyte4.learnsmate.preferred_topics.domain.vo.response.ResponseFindMonthlyStatsVO;
 import intbyte4.learnsmate.preferred_topics.domain.vo.response.ResponseFindPreferredTopicsVO;
 import intbyte4.learnsmate.preferred_topics.mapper.PreferredTopicsMapper;
 import intbyte4.learnsmate.preferred_topics.service.PreferredTopicsService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -69,5 +73,17 @@ public class PreferredTopicsController {
         preferredTopicsService.savePreferredTopics(dtoList);
 
         return ResponseEntity.status(HttpStatus.OK).body("선호 주제 등록 성공");
+    }
+
+    @GetMapping("/monthly-stats")
+    public ResponseEntity<?> getMonthlyCategoryStats(
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
+    ){
+        List<PreferredTopicStatsConvertDTO> dtoList = preferredTopicsService.getMonthlyCategoryStats(startDate, endDate);
+
+        List<ResponseFindMonthlyStatsVO> voList = preferredTopicsMapper.fromPreferredTopicStatsConvertDTOtoVO(dtoList);
+
+        return ResponseEntity.status(HttpStatus.OK).body(voList);
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicStatsConvertDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicStatsConvertDTO.java
@@ -1,0 +1,15 @@
+package intbyte4.learnsmate.preferred_topics.domain.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class PreferredTopicStatsConvertDTO {
+    private String yearMonth;
+    private String lectureCategoryName;
+    private Long topicCount;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicStatsDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicStatsDTO.java
@@ -1,0 +1,16 @@
+package intbyte4.learnsmate.preferred_topics.domain.dto;
+
+import intbyte4.learnsmate.lecture_category.domain.entity.LectureCategoryEnum;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class PreferredTopicStatsDTO {
+    private Integer year; // YEAR(m.createdAt)
+    private Integer month; // MONTH(m.createdAt)
+    private LectureCategoryEnum lectureCategoryName; // lc.lectureCategoryName
+    private Long topicCount; // COUNT(pt.preferredTopicCode)
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicsDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/dto/PreferredTopicsDTO.java
@@ -2,12 +2,11 @@ package intbyte4.learnsmate.preferred_topics.domain.dto;
 
 
 import lombok.*;
-import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
 @RequiredArgsConstructor
 @Getter
-@Service
+@Setter
 @Builder
 @ToString
 public class PreferredTopicsDTO {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/vo/response/ResponseFindMonthlyStatsVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/domain/vo/response/ResponseFindMonthlyStatsVO.java
@@ -1,0 +1,18 @@
+package intbyte4.learnsmate.preferred_topics.domain.vo.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ResponseFindMonthlyStatsVO {
+
+    private String yearMonth; // "YYYY-MM" 형식의 월 정보
+    private String lectureCategoryName;  // 카테고리 이름
+    private Long topicCount;  // 카테고리별 개수
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/mapper/PreferredTopicsMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/mapper/PreferredTopicsMapper.java
@@ -2,9 +2,11 @@ package intbyte4.learnsmate.preferred_topics.mapper;
 
 import intbyte4.learnsmate.lecture_category.domain.entity.LectureCategory;
 import intbyte4.learnsmate.member.domain.entity.Member;
+import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsConvertDTO;
 import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicsDTO;
 import intbyte4.learnsmate.preferred_topics.domain.entity.PreferredTopics;
 import intbyte4.learnsmate.preferred_topics.domain.vo.request.RequestSavePreferredHistoryVO;
+import intbyte4.learnsmate.preferred_topics.domain.vo.response.ResponseFindMonthlyStatsVO;
 import intbyte4.learnsmate.preferred_topics.domain.vo.response.ResponseFindPreferredTopicsVO;
 import org.springframework.stereotype.Component;
 
@@ -48,6 +50,16 @@ public class PreferredTopicsMapper {
                 .map(category -> PreferredTopics.builder()
                         .member(member)
                         .lectureCategory(category)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public List<ResponseFindMonthlyStatsVO> fromPreferredTopicStatsConvertDTOtoVO(List<PreferredTopicStatsConvertDTO> dtoList) {
+        return dtoList.stream()
+                .map(dto -> ResponseFindMonthlyStatsVO.builder()
+                        .yearMonth(dto.getYearMonth())
+                        .lectureCategoryName(dto.getLectureCategoryName())
+                        .topicCount(dto.getTopicCount())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/repository/PreferredTopicsRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/repository/PreferredTopicsRepository.java
@@ -1,13 +1,31 @@
 package intbyte4.learnsmate.preferred_topics.repository;
 
+import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsDTO;
 import intbyte4.learnsmate.preferred_topics.domain.entity.PreferredTopics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface PreferredTopicsRepository extends JpaRepository<PreferredTopics, Long> {
 
     List<PreferredTopics> findByMember_MemberCode(Long memberCode);
+
+    // 입력값 2개에 따라 월별 카테고리별 선호주제 개수 구하는 코드 (2023년도 1월의 7개 강의 카테고리(선호주제)의 비율)
+    @Query("SELECT new intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsDTO(" +
+            "YEAR(m.createdAt), MONTH(m.createdAt), lc.lectureCategoryName, COUNT(pt.preferredTopicCode)) " +
+            "FROM member m " +
+            "JOIN preferredTopics pt ON m.memberCode = pt.member.memberCode " +
+            "JOIN lecture_category lc ON pt.lectureCategory.lectureCategoryCode = lc.lectureCategoryCode " +
+            "WHERE m.createdAt BETWEEN :startDate AND :endDate " +
+            "GROUP BY YEAR(m.createdAt), MONTH(m.createdAt), lc.lectureCategoryName " +
+            "ORDER BY YEAR(m.createdAt), MONTH(m.createdAt), COUNT(pt.preferredTopicCode) DESC")
+    List<PreferredTopicStatsDTO> findCategoryStatsByMonth(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/service/PreferredTopicsService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/preferred_topics/service/PreferredTopicsService.java
@@ -10,6 +10,8 @@ import intbyte4.learnsmate.member.domain.dto.MemberDTO;
 import intbyte4.learnsmate.member.domain.entity.Member;
 import intbyte4.learnsmate.member.mapper.MemberMapper;
 import intbyte4.learnsmate.member.service.MemberService;
+import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsConvertDTO;
+import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicStatsDTO;
 import intbyte4.learnsmate.preferred_topics.domain.dto.PreferredTopicsDTO;
 import intbyte4.learnsmate.preferred_topics.domain.entity.PreferredTopics;
 import intbyte4.learnsmate.preferred_topics.mapper.PreferredTopicsMapper;
@@ -17,6 +19,7 @@ import intbyte4.learnsmate.preferred_topics.repository.PreferredTopicsRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,5 +85,17 @@ public class PreferredTopicsService {
                 = preferredTopicsMapper.fromPreferredTopicsDTOListtoEntityList(member, categoryList);
 
         preferredTopicsRepository.saveAll(preferredTopicList);
+    }
+
+    public List<PreferredTopicStatsConvertDTO> getMonthlyCategoryStats(LocalDateTime startDate, LocalDateTime endDate) {
+        List<PreferredTopicStatsDTO> dtoList = preferredTopicsRepository.findCategoryStatsByMonth(startDate, endDate);
+
+        return dtoList.stream()
+                .map(dto -> PreferredTopicStatsConvertDTO.builder()
+                        .yearMonth(String.format("%04d-%02d", dto.getYear(), dto.getMonth()))
+                        .lectureCategoryName(dto.getLectureCategoryName().toString())
+                        .topicCount(dto.getTopicCount())
+                        .build())
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- 제목 : feat(#196 ): 기능명 ✨ 기능 추가 / 수정: 카테고리 별 학생 비율 그래프 메서드 작성

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
카테고리 별 학생 비율 그래프를 위해서 mvc 메서드를 만들었습니다.
복잡하지 않았는데 JPQL을 작성하는데에서 자꾸 오류가 발생했습니다.

1. 이미지에서 현재는 YEAR, MONTH를 따로 사용하고 있는데 기존 방법의 yearMonth를 가져오기 위해서
FUNCTION('DATE_TIME', ~)메서드를 사용했을때 계속해서 에러가 발생했습니다.
현재까지는 저희가 추가한 hibernate에서 지원하지 않는 포맷이라서 안되는걸로 생각하고 있는데 아직 확실치 않습니다. 이건 추가로 공부해봐야 할거같습니다. 
2. 그리고 lectureCategoryName가 String으로 저장되어있다고 생각해서 String을 고집했었으나 entity에는 enum으로 저장되어 있어서 enum으로 받아왔고 바꾸니 에러가 사라졌습니다.

year, month를 따로 가져왔기 때문에 서비스 코드에서 둘을 '-' 기호를 통해 합쳐주는 부분을 추가했습니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/94eb9305-ba68-4167-8113-d467d93ca913)
![image](https://github.com/user-attachments/assets/7fd69382-8584-4ba5-9c42-b38a6673a535)


<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
다음 통계 데이터 작성 및 DATE_FORMAT 에러 발생 이유 찾기
  <br/>
