### PR TITLE
✨ 기능 추가 : AdminEmailVerificationVO 이메일에 따른 사번 검증 VO 기능 추가

### DIFF
--- a/LearnsMate/build.gradle
+++ b/LearnsMate/build.gradle
@@ -52,6 +52,14 @@ dependencies {
     // EC2 인스턴스 헬스 체크를 위한 actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Redis 통합
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Redis 연결 풀 관리
+    // ( Redis와의 연결을 반복적으로 열고 닫는 대신, 연결을 풀(pool)에 저장해 두고 재사용함으로써 성능을 최적화하고 리소스를 절약 )
+    implementation 'org.apache.commons:commons-pool2'
+    // SMTP 이메일 발송
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     // jwt token을 위한 옵션
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
@@ -116,4 +116,21 @@ public class AdminController {
         }
     }
 
+
+    // 다음버튼
+    @Operation(summary = "비번 재설정 전 이메일 인증번호 검증")
+    @PostMapping("/verification-email/confirmation")
+    public ResponseEmailDTO<?> verifyEmail(@RequestBody @Validated EmailVerificationVO request) {
+        boolean isVerified = emailService.verifyCode(request.getEmail(), request.getCode());
+
+        ResponseEmailMessageVO responseEmailMessageVO =new ResponseEmailMessageVO();
+        responseEmailMessageVO.setMessage("이메일 인증이 완료되었습니다.");
+        if (isVerified) {
+            return ResponseEmailDTO.ok(responseEmailMessageVO);
+        } else {
+            return ResponseEmailDTO.fail(new CommonException(StatusEnum.INVALID_VERIFICATION_CODE));
+        }
+    }
+
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
@@ -132,5 +132,16 @@ public class AdminController {
         }
     }
 
+    // 다음버튼 누를 시, 인증성공하면 ? -> 비번 재설정 칸 생성 -> 완료 버튼
+    @Operation(summary = "비밀번호 재설정")
+    @PostMapping("/password")
+    public ResponseEntity<String> resetPassword(@RequestBody RequestResetPasswordVO request) {
+        log.info("POST /admin/password 요청 도착: email={}", request.getUserEmail());
+        log.info("POST /admin/password 요청 도착: email={}", request.getUserPassword());
 
+        adminService.resetPassword(request);
+
+        log.info("비밀번호가 성공적으로 재설정되었습니다.");
+        return ResponseEntity.ok("비밀번호가 성공적으로 재설정되었습니다.");
+    }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
@@ -88,4 +88,32 @@ public class AdminController {
         return ResponseEntity.ok().body("로그아웃 성공");
     }
 
+    // 인증버튼
+    @Operation(summary = "직원 비밀번호 재설정시 이메일 전송")
+    @PostMapping("/verification-email/password")
+    public ResponseEmailDTO<?> sendVerificationEmailPassword(@RequestBody @Validated AdminEmailVerificationVO request) {
+
+        // 입력한 사번 코드와 이메일의 정보 검증
+        AdminDTO adminByEmail = adminService.findUserByEmail(request.getEmail());
+
+        if (adminByEmail == null || !adminByEmail.getAdminCode().equals(request.getAdminCode())) {
+            throw new CommonException(StatusEnum.EMAIL_NOT_FOUND);
+        }
+        // 이메일로 인증번호 전송
+        return getResponseEmailDTO(request);
+    }
+
+    private ResponseEmailDTO<?> getResponseEmailDTO(AdminEmailVerificationVO request) {
+        // 이메일로 인증번호 전송
+        try {
+            emailService.sendVerificationEmail(request.getEmail());
+
+            ResponseEmailMessageVO responseEmailMessageVO =new ResponseEmailMessageVO();
+            responseEmailMessageVO.setMessage("인증 코드가 이메일로 전송되었습니다.");
+            return ResponseEmailDTO.ok(responseEmailMessageVO);
+        } catch (Exception e) {
+            return ResponseEmailDTO.fail(new CommonException(StatusEnum.INTERNAL_SERVER_ERROR));
+        }
+    }
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
@@ -93,6 +93,8 @@ public class AdminController {
     @PostMapping("/verification-email/password")
     public ResponseEmailDTO<?> sendVerificationEmailPassword(@RequestBody @Validated AdminEmailVerificationVO request) {
 
+        log.info("POST /admin/verification-email/password 요청 도착: request={}", request);
+
         // 입력한 사번 코드와 이메일의 정보 검증
         AdminDTO adminByEmail = adminService.findUserByEmail(request.getEmail());
 
@@ -121,6 +123,8 @@ public class AdminController {
     @Operation(summary = "비번 재설정 전 이메일 인증번호 검증")
     @PostMapping("/verification-email/confirmation")
     public ResponseEmailDTO<?> verifyEmail(@RequestBody @Validated EmailVerificationVO request) {
+        log.info("POST /admin/verification-email/confirmation 요청 도착: request={}", request);
+
         boolean isVerified = emailService.verifyCode(request.getEmail(), request.getCode());
 
         ResponseEmailMessageVO responseEmailMessageVO =new ResponseEmailMessageVO();
@@ -136,8 +140,7 @@ public class AdminController {
     @Operation(summary = "비밀번호 재설정")
     @PostMapping("/password")
     public ResponseEntity<String> resetPassword(@RequestBody RequestResetPasswordVO request) {
-        log.info("POST /admin/password 요청 도착: email={}", request.getUserEmail());
-        log.info("POST /admin/password 요청 도착: email={}", request.getUserPassword());
+        log.info("POST /admin/password 요청 도착: request={}", request);
 
         adminService.resetPassword(request);
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/AdminController.java
@@ -1,12 +1,20 @@
 package intbyte4.learnsmate.admin.controller;
 
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+import intbyte4.learnsmate.admin.domain.dto.ResponseEmailDTO;
 import intbyte4.learnsmate.admin.domain.entity.CustomUserDetails;
+import intbyte4.learnsmate.admin.domain.vo.request.AdminEmailVerificationVO;
+import intbyte4.learnsmate.admin.domain.vo.request.EmailVerificationVO;
 import intbyte4.learnsmate.admin.domain.vo.request.RequestEditAdminVO;
+import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import intbyte4.learnsmate.admin.domain.vo.response.ResponseEditAdminVO;
+import intbyte4.learnsmate.admin.domain.vo.response.ResponseEmailMessageVO;
 import intbyte4.learnsmate.admin.domain.vo.response.ResponseFindAdminVO;
 import intbyte4.learnsmate.admin.mapper.AdminMapper;
 import intbyte4.learnsmate.admin.service.AdminService;
+import intbyte4.learnsmate.admin.service.EmailService;
+import intbyte4.learnsmate.common.exception.CommonException;
+import intbyte4.learnsmate.common.exception.StatusEnum;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -28,6 +37,7 @@ public class AdminController {
 
     private final AdminService adminService;
     private final AdminMapper adminMapper;
+    private final EmailService emailService;
 
     @Operation(summary = "직원 단건 조회")
     @GetMapping("/{adminCode}")
@@ -37,10 +47,9 @@ public class AdminController {
     }
 
     @Operation(summary = "직원 정보 수정")
-    @PatchMapping("/{adminCode}")
-    public ResponseEntity<ResponseEditAdminVO> updateAdmin(@PathVariable Long adminCode,
-                                                           @RequestBody RequestEditAdminVO editAdminVO) {
-        AdminDTO updatedAdmin = adminService.updateAdmin(adminCode, adminMapper.fromVoToDto(editAdminVO));
+    @PatchMapping("/password")
+    public ResponseEntity<ResponseEditAdminVO> updateAdmin(@RequestBody RequestEditAdminVO editAdminVO) {
+        AdminDTO updatedAdmin = adminService.updateAdmin(adminMapper.fromVoToDto(editAdminVO));
         return ResponseEntity.status(HttpStatus.OK).body(adminMapper.fromDtoToEditResponseVO(updatedAdmin));
     }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/dto/ResponseEmailDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/dto/ResponseEmailDTO.java
@@ -1,0 +1,71 @@
+package intbyte4.learnsmate.admin.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import intbyte4.learnsmate.common.exception.CommonException;
+import intbyte4.learnsmate.common.exception.ExceptionDTO;
+import intbyte4.learnsmate.common.exception.StatusEnum;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseEmailDTO<T> {
+
+    @JsonIgnore
+    private HttpStatus httpStatus;
+
+    @NotNull
+    private boolean success;
+
+    @Nullable
+    private T data;
+
+    @Nullable
+    private ExceptionDTO error;
+
+    // static 팩토리 메소드
+    public static <T> ResponseEmailDTO<T> ok(T data) {
+        return new ResponseEmailDTO<>(
+                HttpStatus.OK,
+                true,
+                data,
+                null
+        );
+    }
+
+    public static ResponseEmailDTO<Object> fail(@NotNull CommonException e) {
+        return new ResponseEmailDTO<>(
+                e.getStatusEnum().getHttpStatus(),
+                false,
+                null,
+                ExceptionDTO.of(e.getStatusEnum())
+        );
+    }
+
+    public static ResponseEmailDTO<Object> fail(final MissingServletRequestParameterException e) {
+        return new ResponseEmailDTO<>(
+                HttpStatus.BAD_REQUEST,
+                false,
+                null,
+                ExceptionDTO.of(StatusEnum.MISSING_REQUEST_PARAMETER)
+        );
+    }
+
+    public static ResponseEmailDTO<Object> fail(final MethodArgumentTypeMismatchException e) {
+        return new ResponseEmailDTO<>(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                false,
+                null,
+                ExceptionDTO.of(StatusEnum.INVALID_PARAMETER_FORMAT)
+        );
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/entity/Admin.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/entity/Admin.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @ToString
 @Getter
+@Setter
 @Builder
 public class Admin {
     @Id

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/AdminEmailVerificationVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/AdminEmailVerificationVO.java
@@ -1,0 +1,19 @@
+package intbyte4.learnsmate.admin.domain.vo.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class AdminEmailVerificationVO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/EmailVerificationVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/EmailVerificationVO.java
@@ -1,0 +1,19 @@
+package intbyte4.learnsmate.admin.domain.vo.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailVerificationVO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
+
+    @NotBlank
+    private Long adminCode;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/RequestResetPasswordVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/RequestResetPasswordVO.java
@@ -1,0 +1,22 @@
+package intbyte4.learnsmate.admin.domain.vo.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class RequestResetPasswordVO {
+
+    @NotBlank
+    @Email
+    String userEmail;
+
+    @NotBlank
+    String userPassword;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/response/ResponseEmailMessageVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/response/ResponseEmailMessageVO.java
@@ -1,0 +1,12 @@
+package intbyte4.learnsmate.admin.domain.vo.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class ResponseEmailMessageVO {
+
+    @JsonProperty("message")
+    private String message;
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
@@ -1,10 +1,15 @@
 package intbyte4.learnsmate.admin.service;
 
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
+import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface AdminService extends UserDetailsService {
     AdminDTO findByAdminCode(Long adminCode);
 
-    AdminDTO updateAdmin(Long adminCode, AdminDTO editAdminVO);
+    AdminDTO updateAdmin(AdminDTO editAdminVO);
+
+    AdminDTO findUserByEmail(String adminEmail);
+
+    void resetPassword(RequestResetPasswordVO request);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
@@ -4,20 +4,18 @@ package intbyte4.learnsmate.admin.service;
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
 import intbyte4.learnsmate.admin.domain.entity.Admin;
 import intbyte4.learnsmate.admin.domain.entity.CustomUserDetails;
+import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import intbyte4.learnsmate.admin.mapper.AdminMapper;
 import intbyte4.learnsmate.admin.repository.AdminRepository;
 import intbyte4.learnsmate.common.exception.CommonException;
 import intbyte4.learnsmate.common.exception.StatusEnum;
-import intbyte4.learnsmate.member.domain.MemberType;
-import intbyte4.learnsmate.member.domain.dto.MemberDTO;
-import intbyte4.learnsmate.member.mapper.MemberMapper;
-import intbyte4.learnsmate.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -29,6 +27,7 @@ import java.util.List;
 public class AdminServiceImpl implements AdminService {
 
     private final AdminRepository adminRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final AdminMapper adminMapper;
 
     @Override
@@ -38,8 +37,8 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public AdminDTO updateAdmin(Long adminCode, AdminDTO adminDTO) {
-        Admin admin = adminRepository.findById(adminCode)
+    public AdminDTO updateAdmin(AdminDTO adminDTO) {
+        Admin admin = adminRepository.findById(adminDTO.getAdminCode())
                 .orElseThrow(() -> new CommonException(StatusEnum.ADMIN_NOT_FOUND));
         admin.toUpdate(adminDTO);
         Admin updatedAdmin = adminRepository.save(admin);
@@ -64,6 +63,7 @@ public class AdminServiceImpl implements AdminService {
         AdminDTO adminDTO = adminMapper.toDTO(admin);
         return new CustomUserDetails(adminDTO, grantedAuthorities, true, true, true, true);
     }
+
 
 }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
@@ -65,5 +65,16 @@ public class AdminServiceImpl implements AdminService {
     }
 
 
+    @Override
+    public AdminDTO findUserByEmail(String adminEmail) {
+        Admin admin = adminRepository.findByAdminEmail(adminEmail);
+        if (admin == null) {
+            throw new CommonException(StatusEnum.ADMIN_NOT_FOUND);
+        }
+        return adminMapper.toDTO(admin);
+    }
+
+
+
 }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
@@ -74,7 +74,20 @@ public class AdminServiceImpl implements AdminService {
         return adminMapper.toDTO(admin);
     }
 
+    @Override
+    public void resetPassword(RequestResetPasswordVO request) {
 
+        Admin admin = adminRepository.findByAdminEmail(request.getUserEmail());
+        if (admin == null) {
+            throw new CommonException(StatusEnum.ADMIN_NOT_FOUND);
+        }
+
+        // 비밀번호 bCrypt 암호화.
+        admin.setAdminPassword(bCryptPasswordEncoder.encode(request.getUserPassword()));
+
+        Admin updatedAdmin = adminRepository.save(admin);
+        adminMapper.toDTO(updatedAdmin);
+    }
 
 }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/EmailService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/EmailService.java
@@ -1,0 +1,76 @@
+package intbyte4.learnsmate.admin.service;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+public class EmailService {
+
+    private JavaMailSender mailSender;
+    private StringRedisTemplate stringRedisTemplate;  // StringRedisTemplate 사용
+
+    @Autowired
+    public EmailService(StringRedisTemplate stringRedisTemplate, JavaMailSender mailSender) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.mailSender = mailSender;
+    }
+
+    private final long VERIFICATION_CODE_TTL = 5; // 5분
+
+    public void sendVerificationEmail(String email) {
+        log.info("start sending verification email");
+        String verificationCode = generateVerificationCode();
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[LearnsMate] 이메일 인증 코드 안내");
+        message.setText("안녕하세요,\n\n"
+                + "LearnsMate를 이용해 주셔서 진심으로 감사드립니다.\n"
+                + "아래의 인증 코드를 입력하여 이메일 인증을 완료해 주시기 바랍니다.\n\n"
+                + "인증 코드: " + verificationCode + "\n\n"
+                + "※ 인증 코드는 발송 후 5분간만 유효합니다.\n\n"
+                + "본 이메일은 LearnsMate 서비스 이용과 관련하여 발송되었습니다. "
+                + "궁금하신 사항이 있으시면 LearnsMate 고객 지원팀으로 언제든 문의해 주시기 바랍니다.\n\n"
+                + "감사합니다.\n\n"
+                + "LearnsMate 드림");
+
+        mailSender.send(message);
+
+        saveVerificationCode(email, verificationCode);
+    }
+
+    //필기. 해당 이메일의 코드가 일치하는지 확인하는 코드
+    public boolean verifyCode(String email, String code) {
+        String savedCode = stringRedisTemplate.opsForValue().get(email);  //필기. Redis에서 코드 가져오기
+
+        // 필기. 인증 코드가 일치하면 Redis에서 해당 키값(email)을 True로 설정
+        if (savedCode != null && savedCode.equals(code)) {
+            // 인증 성공 시 Redis에 True 저장하고 TTL을 1시간으로 설정
+            stringRedisTemplate.opsForValue().set(email, "True", 1, TimeUnit.HOURS);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    //필기. Redis에 코드 저장
+    private void saveVerificationCode(String email, String code) {
+        stringRedisTemplate.opsForValue().set(email, code, VERIFICATION_CODE_TTL, TimeUnit.MINUTES);
+    }
+
+    //필기. 6자리 난수 발생 (0~999999)
+    private String generateVerificationCode() {
+        Random random = new Random();
+        int code = random.nextInt(999999);
+        return String.format("%06d", code);
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/EmailConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/EmailConfig.java
@@ -1,0 +1,50 @@
+package intbyte4.learnsmate.common.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.smtp.host}")
+    private String host;
+
+    @Value("${spring.mail.smtp.port}")
+    private int port;
+
+    @Value("${spring.mail.smtp.username}")
+    private String username;
+
+    @Value("${spring.mail.smtp.password}")
+    private String password;
+
+    @Value("${spring.mail.smtp.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.smtp.properties.mail.smtp.ssl.enable}")
+    private boolean sslEnable;
+
+    @Bean
+    public JavaMailSender mailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.ssl.enable", sslEnable);
+        props.put("mail.smtp.ssl.trust", host);
+
+        return mailSender;
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package intbyte4.learnsmate.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    /*
+     * RedisConnection 에서 넘겨준 byte 값을 직렬화 RedisTemplate 은
+     * Redis 데이터를 저장하고 조회하는 기능을 하는 클래스 REdis cli 를 사용해 Redis 데이터를 직접 조회할때,
+     * Redis 데이터를 문자열로 반환하기 위한 설정
+     */
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/AuthenticationFilter.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/AuthenticationFilter.java
@@ -104,7 +104,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         jwtCookie.setSecure(false); // HTTPS 연결에서만 전송 (테스트 환경에서는 false 설정 가능)
         // https://learnsmate.site -> 배포 환경시 true로 전환
         jwtCookie.setPath("/"); // 쿠키의 유효 경로 설정 (애플리케이션 전체에 사용 가능)
-        jwtCookie.setMaxAge(7 * 24 * 60 * 60); // 쿠키 만료 시간 설정 (7일)
+        jwtCookie.setMaxAge(4 * 3600); // 쿠키 만료 시간 설정 (4시간)
         // 여기를 3-4시간정도로 만료시간 할건데 리프레시토큰을 해야하나? erp라 재로그인이 필요하지않을까
 
         // 응답에 쿠키 추가


### PR DESCRIPTION
- 제목 : feat:✨ 기능 추가 : AdminEmailVerificationVO 이메일에 따른 사번 검증 VO 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
[POST} /admin/verification-email/password -> 인증버튼(비밀번호 재설정시 이메일 전송 API)
[POST} /admin/verification-email/confirmation -> 다음 버튼(비번 재설정 전 이메일 인증번호 검증)
[POST} /admin/password -> // 다음버튼 누를 시, 인증성공하면 ? -> 비번 재설정 칸 생성 -> 완료 버튼(비밀번호 재설정)

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/4bcbd2a0-3d8d-42fc-b61e-e400fdeb267c)


<br/>

## 🔧 앞으로의 과제

- 리프레시 토큰도 발행 후,  레디스에 담기

  <br/>
