### PR TITLE
✨ 기능 추가 :만료된 Access Token에서 사용자 ID 유효성 검증 기능 추가

### DIFF
--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
@@ -1,0 +1,62 @@
+package intbyte4.learnsmate.admin.controller;
+
+import intbyte4.learnsmate.admin.domain.dto.JwtTokenDTO;
+import intbyte4.learnsmate.security.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/auth")
+public class TokenController {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Operation(summary = "토큰 리프레시 요청")
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@CookieValue("accessToken") String expiredToken, HttpServletRequest request, HttpServletResponse response) {
+        try {
+            // 만료된 Access Token에서 사용자 ID 추출
+            String userCode = jwtUtil.extractUserCode(expiredToken);
+
+            // Redis에서 Refresh Token 확인
+            String refreshToken = redisTemplate.opsForValue().get("refreshToken:" + userCode);
+            if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+                throw new RuntimeException("유효하지 않은 Refresh Token입니다.");
+            }
+
+            // 새로운 Access Token 발급
+            String newAccessToken = jwtUtil.generateToken(
+                    new JwtTokenDTO(userCode, null, null),
+                    List.of("ROLE_USER"),null
+            );
+
+            // 새 Access Token을 HttpOnly 쿠키에 저장
+            Cookie accessTokenCookie = new Cookie("accessToken", newAccessToken);
+            accessTokenCookie.setHttpOnly(true);
+            accessTokenCookie.setSecure(false);
+            accessTokenCookie.setPath("/");
+            accessTokenCookie.setMaxAge(15 * 60);
+            response.addCookie(accessTokenCookie);
+
+            return ResponseEntity.ok("새로운 Access Token 발급 완료");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("재발급 실패: " + e.getMessage());
+        }
+    }
+
+
+}
+

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
@@ -57,6 +57,15 @@ public class TokenController {
         }
     }
 
-
+    //Postman으로 refreshToken값 조회
+    @Operation(summary = "Redis에 담긴 refreshToken값 조회")
+    @GetMapping("/check-refresh-token/{userCode}")
+    public ResponseEntity<String> checkRefreshToken(@PathVariable String userCode) {
+        String refreshToken = redisTemplate.opsForValue().get("refreshToken:" + userCode);
+        if (refreshToken != null) {
+            return ResponseEntity.ok(refreshToken);
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Refresh Token not found");
+    }
 }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/RequestResetPasswordVO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/domain/vo/request/RequestResetPasswordVO.java
@@ -15,8 +15,8 @@ public class RequestResetPasswordVO {
 
     @NotBlank
     @Email
-    String userEmail;
+    String adminEmail;
 
     @NotBlank
-    String userPassword;
+    String adminPassword;
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/mapper/AdminMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/mapper/AdminMapper.java
@@ -99,5 +99,11 @@ public class AdminMapper {
                 .build();
     }
 
+    public AdminDTO fromResetPasswordVoToDto(RequestResetPasswordVO requestVO) {
+        return AdminDTO.builder()
+                .adminEmail(requestVO.getAdminEmail())
+                .adminPassword(requestVO.getAdminPassword())
+                .build();
+    }
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/mapper/AdminMapper.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/mapper/AdminMapper.java
@@ -2,7 +2,9 @@ package intbyte4.learnsmate.admin.mapper;
 
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
 import intbyte4.learnsmate.admin.domain.entity.Admin;
+import intbyte4.learnsmate.admin.domain.vo.request.AdminEmailVerificationVO;
 import intbyte4.learnsmate.admin.domain.vo.request.RequestEditAdminVO;
+import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import intbyte4.learnsmate.admin.domain.vo.response.ResponseEditAdminVO;
 import intbyte4.learnsmate.admin.domain.vo.response.ResponseFindAdminVO;
 import org.springframework.stereotype.Component;
@@ -55,7 +57,7 @@ public class AdminMapper {
     }
 
     // RequestEditAdminVO -> AdminDTO 변환
-    public AdminDTO fromVoToDto(RequestEditAdminVO requestEditAdminVO) {
+    public AdminDTO fromAdminEmailVoToDto(RequestEditAdminVO requestEditAdminVO) {
         return AdminDTO.builder()
                 .adminEmail(requestEditAdminVO.getAdminEmail())
                 .adminPassword(requestEditAdminVO.getAdminPassword())
@@ -89,5 +91,13 @@ public class AdminMapper {
                 .adminLastLoginDate(adminDTO.getAdminLastLoginDate())
                 .build();
     }
+
+    public AdminDTO fromAdminEmailVoToDto(AdminEmailVerificationVO requestVO) {
+        return AdminDTO.builder()
+                .adminEmail(requestVO.getEmail())
+                .adminCode(requestVO.getAdminCode())
+                .build();
+    }
+
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminService.java
@@ -1,7 +1,6 @@
 package intbyte4.learnsmate.admin.service;
 
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
-import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface AdminService extends UserDetailsService {
@@ -11,5 +10,5 @@ public interface AdminService extends UserDetailsService {
 
     AdminDTO findUserByEmail(String adminEmail);
 
-    void resetPassword(RequestResetPasswordVO request);
+    void resetPassword(AdminDTO request);
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/AdminServiceImpl.java
@@ -4,7 +4,6 @@ package intbyte4.learnsmate.admin.service;
 import intbyte4.learnsmate.admin.domain.dto.AdminDTO;
 import intbyte4.learnsmate.admin.domain.entity.Admin;
 import intbyte4.learnsmate.admin.domain.entity.CustomUserDetails;
-import intbyte4.learnsmate.admin.domain.vo.request.RequestResetPasswordVO;
 import intbyte4.learnsmate.admin.mapper.AdminMapper;
 import intbyte4.learnsmate.admin.repository.AdminRepository;
 import intbyte4.learnsmate.common.exception.CommonException;
@@ -75,15 +74,15 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public void resetPassword(RequestResetPasswordVO request) {
+    public void resetPassword(AdminDTO request) {
 
-        Admin admin = adminRepository.findByAdminEmail(request.getUserEmail());
+        Admin admin = adminRepository.findByAdminEmail(request.getAdminEmail());
         if (admin == null) {
             throw new CommonException(StatusEnum.ADMIN_NOT_FOUND);
         }
 
         // 비밀번호 bCrypt 암호화.
-        admin.setAdminPassword(bCryptPasswordEncoder.encode(request.getUserPassword()));
+        admin.setAdminPassword(bCryptPasswordEncoder.encode(request.getAdminPassword()));
 
         Admin updatedAdmin = adminRepository.save(admin);
         adminMapper.toDTO(updatedAdmin);

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/exception/StatusEnum.java
@@ -48,6 +48,7 @@ public enum StatusEnum {
     INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
 
     INVALID_VERIFICATION_CODE(400, HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+    INVALID_TOKEN(400, HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
     EMAIL_VERIFICATION_REQUIRED(400, HttpStatus.BAD_REQUEST, "이메일 인증이 필요합니다."),
 
     EXISTING_CONTRACT_PROCESS(409, HttpStatus.CONFLICT, "존재하는 강의 계약과정입니다."),

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/report/controller/ReportController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/report/controller/ReportController.java
@@ -4,6 +4,7 @@ import intbyte4.learnsmate.report.domain.dto.ReportDTO;
 import intbyte4.learnsmate.report.domain.vo.response.ResponseFindReportVO;
 import intbyte4.learnsmate.report.mapper.ReportMapper;
 import intbyte4.learnsmate.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,7 @@ public class ReportController {
     }
 
     // 1. 모든 신고 내역 조회 // /report
+    @Operation(summary = "신고 내역 전체 조회")
     @GetMapping
     public ResponseEntity<List<ResponseFindReportVO>> findAllReport(){
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/AuthenticationFilter.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/AuthenticationFilter.java
@@ -130,6 +130,29 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     }
 
 
+    // Redis에 refreshToken 저장
+    public void saveRefreshTokenToRedis(String userCode, String refreshToken) {
+        try {
+            // Redis에 refreshToken 저장
+            redisTemplate.opsForValue().set(
+                    "refreshToken:" + userCode,
+                    refreshToken,
+                    7, // 7일
+                    TimeUnit.DAYS
+            );
+
+            // 로그로 저장된 refreshToken 확인
+            log.info("Refresh Token 저장 완료: refreshToken:{}, userCode:{}", refreshToken, userCode);
+
+            // Redis에서 값을 확인 (디버깅용)
+            String storedToken = redisTemplate.opsForValue().get("refreshToken:" + userCode);
+            log.info("Redis에서 가져온 refreshToken: {}", storedToken);
+
+        } catch (Exception e) {
+            log.error("Redis 저장 실패", e);
+        }
+    }
+
     //로그인 실패시 실행하는 메소드
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/JwtUtil.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/JwtUtil.java
@@ -109,6 +109,20 @@ public class JwtUtil {
                 .compact();
     }
 
+    // 리프레시 토큰은 단순히 새로운 액세스 토큰 발급을 요청하기 위한 용도
+    public String generateRefreshToken(JwtTokenDTO tokenDTO) {
+        Claims claims = Jwts.claims().setSubject(tokenDTO.getUserCode()); // 최소한의 정보
+        log.info("RefreshToken Claims 생성: {}", claims);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 7)) // 7일 만료
+                .signWith(SignatureAlgorithm.HS512, secretKey)
+                .compact();
+    }
+
+
     public String getEmailFromToken(String token) {
         return getClaimFromToken(token, claims -> claims.get("email", String.class));
     }
@@ -146,4 +160,7 @@ public class JwtUtil {
     public String getUserCodeFromToken(String token) {
         return getClaimFromToken(token, Claims::getSubject);
     }
+
+
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
@@ -2,14 +2,13 @@ package intbyte4.learnsmate.security;
 
 import intbyte4.learnsmate.admin.service.AdminService;
 import jakarta.servlet.Filter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,16 +28,18 @@ import java.util.Collections;
 public class WebSecurity {
 
     private BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final RedisTemplate<String, String> redisTemplate;
     private AdminService userService;
     private Environment env;
     private JwtUtil jwtUtil;
 
     @Autowired
-    public WebSecurity(BCryptPasswordEncoder bCryptPasswordEncoder, AdminService userService, Environment env, JwtUtil jwtUtil) {
+    public WebSecurity(BCryptPasswordEncoder bCryptPasswordEncoder, AdminService userService, Environment env, JwtUtil jwtUtil, RedisTemplate<String, String> redisTemplate) {
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.userService = userService;
         this.env = env;
         this.jwtUtil = jwtUtil;
+        this.redisTemplate = redisTemplate;
     }
 
 
@@ -65,16 +66,12 @@ public class WebSecurity {
                                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/index.html", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**", "GET")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/users/verification-email/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/users/verify-code")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/users/send-sms")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/admin/**","GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/admin/**","POST")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "POST")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "OPTIONS")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/users/**", "PATCH")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/users/mypage/edit/password", "PATCH")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/voc/list", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/voc/count-by-category", "GET")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/voc/filter", "POST")).permitAll()
@@ -136,7 +133,7 @@ public class WebSecurity {
 
     // Authentication 용 메소드(인증 필터 반환)
     private Filter getAuthenticationFilter(AuthenticationManager authenticationManager) {
-        return new AuthenticationFilter(authenticationManager, userService, env, jwtUtil);
+        return new AuthenticationFilter(authenticationManager, userService, env, jwtUtil, redisTemplate);
     }
 
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VOCAiController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/voc/controller/VOCAiController.java
@@ -2,6 +2,7 @@ package intbyte4.learnsmate.voc.controller;
 
 import intbyte4.learnsmate.voc.domain.VOCAiAnswer;
 import intbyte4.learnsmate.voc.service.VOCAiService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ public class VOCAiController {
 
     private final VOCAiService vocAiService;
 
+    @Operation(summary = "이번 주차 voc 분석 조회")
     @GetMapping("/current-week")
     public ResponseEntity<List<VOCAiAnswer>> getCurrentWeekAnalysis() {
         LocalDate currentWeekMonday = vocAiService.getCurrentWeekMonday();
@@ -32,6 +34,7 @@ public class VOCAiController {
         return ResponseEntity.ok(analysisData);
     }
 
+    @Operation(summary = "voc 분석 월요일 주차 별 조회")
     @GetMapping("/by-date")
     public ResponseEntity<List<VOCAiAnswer>> getAnalysisByDate(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         List<VOCAiAnswer> analysisData = vocAiService.getAnalysisByDate(date);


### PR DESCRIPTION
- 제목 : feat: ✨ 기능 추가 :만료된 Access Token에서 사용자 ID 유효성 검증 기능 추가

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
Access Token은 쿠키에 담아 요청마다 서버에 자동 전달.
Refresh Token은 Redis에만 저장하여 클라이언트는 Refresh Token을 직접 사용하지 않음.
Access Token 만료 시, 클라이언트는 서버에 Refresh Token 요청.
서버는 Redis에서 Refresh Token 검증 후 새로운 Access Token 발급.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/f3120053-1f2f-4517-a901-46d5e03fd946)

<br/>

## 🔧 앞으로의 과제

- 프론트랑 api 연동하기 

  <br/>
