### PR TITLE
✨ 기능 수정 : RedisConfig 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
               redis:
                 host: \${REDIS_HOST}
                 port: 6379
+                repositories:
+                  enabled: false
                 lettuce:
                   pool:
                     max-active: 50

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
@@ -2,12 +2,14 @@ package intbyte4.learnsmate.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@EnableJpaRepositories
 public class AppConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
@@ -18,6 +18,4 @@ public class AppConfig {
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
-    @Bean
-    public RestTemplate restTemplate() { return new RestTemplate(); }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
@@ -1,15 +1,15 @@
 package intbyte4.learnsmate.common.config;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@EnableJpaRepositories
 public class AppConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/AppConfig.java
@@ -18,4 +18,7 @@ public class AppConfig {
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Bean
+    public RestTemplate restTemplate() { return new RestTemplate(); }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/BatchConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/BatchConfig.java
@@ -14,6 +14,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -22,6 +23,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @RequiredArgsConstructor
 @EnableBatchProcessing
 public class BatchConfig {
+
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
 
@@ -46,7 +48,8 @@ public class BatchConfig {
                 .build();
     }
 
-
-
+    @Bean
+    public static BeanDefinitionRegistryPostProcessor jobRegistryBeanPostProcessorRemover() {
+        return registry -> registry.removeBeanDefinition("jobRegistryBeanPostProcessor");
+    }
 }
-

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
@@ -5,8 +5,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
+@EnableRedisRepositories
 public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/RedisConfig.java
@@ -5,10 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
@@ -116,6 +116,7 @@ public class WebSecurity {
                 // 서버가 세션을 생성하지 않음
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
+        http.addFilter(getAuthenticationFilter(authenticationManager));
         http.addFilterBefore(new JwtFilter(userService, jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
trationDelegate$BeanPostProcessorChecker : Bean 'jobRegistry' of type [org.springframework.batch.core.configuration.support.MapJobRegistry] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [jobRegistryBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies/advisors. If this bean does not have to be post-processed, declare it with ROLE_INFRASTRUCTURE.

위와 같은 오류가 뜨는 것 같아 수정해봤습니다.